### PR TITLE
BUG: Modify match words for catching error message

### DIFF
--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -309,7 +309,7 @@ class MainActorPool(MainActorPoolBase):
         try:
             return await asyncio.to_thread(process.is_alive)
         except RuntimeError as ex:  # pragma: no cover
-            if "cannot schedule new futures after interpreter shutdown" not in str(ex):
+            if "cannot schedule new futures" not in str(ex):
                 # when atexit is triggered, the default pool might be shutdown
                 # and to_thread will fail
                 raise

--- a/python/xoscar/backends/pool.py
+++ b/python/xoscar/backends/pool.py
@@ -1408,10 +1408,7 @@ class MainActorPoolBase(ActorPoolBase):
                     except asyncio.CancelledError:
                         raise
                     except RuntimeError as ex:  # pragma: no cover
-                        if (
-                            "cannot schedule new futures after interpreter shutdown"
-                            not in str(ex)
-                        ):
+                        if "cannot schedule new futures" not in str(ex):
                             # to silence log when process exit, otherwise it
                             # will raise "RuntimeError: cannot schedule new futures
                             # after interpreter shutdown".


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

For some versions of Python, it raises RuntimeError: cannot schedule new futures after shutdown, use "cannot schedule new futures " to match error message.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
