### PR TITLE
BUG: The bytes returned by cuda StreamReader may leads to deserialization failed

### DIFF
--- a/python/xoscar/backends/communication/utils.py
+++ b/python/xoscar/backends/communication/utils.py
@@ -74,8 +74,8 @@ async def read_buffers(header: Dict, reader: StreamReader):
     for is_cuda_buffer, buf_size in zip(is_cuda_buffers, buffer_sizes):
         if is_cuda_buffer:  # pragma: no cover
             if buf_size == 0:
-                content = await reader.readexactly(buf_size)
-                buffers.append(content)
+                # uniformly use rmm.DeviceBuffer for cuda's deserialization
+                buffers.append(rmm.DeviceBuffer(size=buf_size))
             else:
                 buffer = rmm.DeviceBuffer(size=buf_size)
                 arr = _convert_to_cupy_ndarray(buffer)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
When I adapt ``copy_to`` to ``xorbits``, xoscar cannot deserialize the transferred cupy object. 
In xorbits, all the cuda object will use ``rmm.DeviceBuffer``-based object to store actual data. 
But in xoscar, the result of deserialization could be the organic ``bytes`` object.
I think using ``rmm.DeviceBuffer`` is definitely correct.

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
