### PR TITLE
BUG: disable import cuda error when cpu only in a shared python env

### DIFF
--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -77,7 +77,7 @@ cdef class TypeDispatcher:
                 imported = True
             except Exception as e:  # pragma: no cover
                 imported = False
-                warnings.warn(str(e))
+                warnings.warn(f'Import {mod_name} failed. Please check your current Python environment.')
 
             if imported:
                 self.register(getattr(mod, obj_name), v)

--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -66,13 +66,21 @@ cdef class TypeDispatcher:
     cdef _reload_lazy_handlers(self):
         for k, v in self._lazy_handlers.items():
             mod_name, obj_name = k.rsplit('.', 1)
-            with warnings.catch_warnings():
-                # the lazy imported cudf will warn no device found,
-                # when we set visible device to -1 for CPU processes,
-                # ignore the warning to not distract users
-                warnings.simplefilter("ignore")
-                mod = importlib.import_module(mod_name, __name__)
-            self.register(getattr(mod, obj_name), v)
+            imported = False
+            try:
+                with warnings.catch_warnings():
+                    # the lazy imported cudf will warn no device found,
+                    # when we set visible device to -1 for CPU processes,
+                    # ignore the warning to not distract users
+                    warnings.simplefilter("ignore")
+                    mod = importlib.import_module(mod_name, __name__)
+                imported = True
+            except Exception as e:  # pragma: no cover
+                imported = False
+                warnings.warn(str(e))
+
+            if imported:
+                self.register(getattr(mod, obj_name), v)
         self._lazy_handlers = dict()
 
     cpdef get_handler(self, object type_):

--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -75,7 +75,9 @@ cdef class TypeDispatcher:
                     warnings.simplefilter("ignore")
                     mod = importlib.import_module(mod_name, __name__)
                 imported = True
-            except Exception as e:  # pragma: no cover
+            # The reason all exceptions are caught here instead of ImportError is that
+            # when, for example, a cpu machine tries to import cuda, the exception thrown is CudaAPIError.
+            except:  # pragma: no cover
                 imported = False
                 warnings.warn(f'Import {mod_name} failed. Please check your current Python environment.')
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

Shared python environments that contain cuda-related environments but do not actually have GPU environments on the machine only show warnings.

Fixes https://github.com/xorbitsai/xorbits/issues/595

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
