### PR TITLE
FEAT: Support nccl in collective communication

### DIFF
--- a/python/xoscar/collective/tests/test_cupy.py
+++ b/python/xoscar/collective/tests/test_cupy.py
@@ -21,8 +21,6 @@ import pytest
 
 from .. import xoscar_cupy as xc
 
-mp.set_start_method("spawn")
-
 
 def worker_allreduce(rank, nccl_id, device_id):
     cupy.cuda.Device(device_id).use()
@@ -239,6 +237,8 @@ def worker_scatter_buffer(rank, nccl_id, device_id):
     ],
 )
 def test_driver(worker_func):
+    mp.set_start_method("spawn", force=True)
+
     nccl_id = nccl.get_unique_id()
     device_id = [0, 1]
 

--- a/python/xoscar/collective/tests/test_cupy.py
+++ b/python/xoscar/collective/tests/test_cupy.py
@@ -221,54 +221,6 @@ def test_scatter_buffer(rank, nccl_id, device_id):
     cupy.testing.assert_array_equal(buffer_chunks[1], cupy.array([[3], [4]]))
 
 
-def test_get_buffer_ptr():
-    import numpy as np
-
-    buffer = cupy.array([1, 2, 3], dtype=cupy.float32)
-
-    ptr = xc.get_buffer_ptr(buffer)
-    assert isinstance(ptr, int)
-    assert ptr == buffer.data.ptr
-
-    with pytest.raises(ValueError, match="Buffer type not supported"):
-        list_buffer = [1, 2, 3]
-        xc.get_buffer_ptr(list_buffer)
-
-    with pytest.raises(ValueError, match="Buffer type not supported"):
-        np_buffer = np.array([1, 2, 3])
-        xc.get_buffer_ptr(np_buffer)
-
-
-def test_get_nccl_buffer_dtype():
-    import numpy as np
-
-    CUPY_NCCL_DTYPE_MAP = {
-        cupy.uint8: nccl.NCCL_UINT8,
-        cupy.uint32: nccl.NCCL_UINT32,
-        cupy.uint64: nccl.NCCL_UINT64,
-        cupy.int8: nccl.NCCL_INT8,
-        cupy.int32: nccl.NCCL_INT32,
-        cupy.int64: nccl.NCCL_INT64,
-        cupy.half: nccl.NCCL_HALF,
-        cupy.float16: nccl.NCCL_FLOAT16,
-        cupy.float32: nccl.NCCL_FLOAT32,
-        cupy.float64: nccl.NCCL_FLOAT64,
-        cupy.double: nccl.NCCL_DOUBLE,
-    }
-
-    for cupy_dtype in CUPY_NCCL_DTYPE_MAP:
-        buffer = cupy.array([1, 2, 3], dtype=cupy_dtype)
-        assert xc.get_nccl_buffer_dtype(buffer) == CUPY_NCCL_DTYPE_MAP[cupy_dtype]
-
-    with pytest.raises(ValueError, match="Buffer type not supported"):
-        list_buffer = [1, 2, 3]
-        xc.get_nccl_buffer_dtype(list_buffer)
-
-    with pytest.raises(ValueError, match="Buffer type not supported"):
-        np_buffer = np.array([1, 2, 3])
-        xc.get_nccl_buffer_dtype(np_buffer)
-
-
 @pytest.mark.parametrize(
     "worker_func",
     [

--- a/python/xoscar/collective/tests/test_cupy.py
+++ b/python/xoscar/collective/tests/test_cupy.py
@@ -16,13 +16,13 @@ import multiprocessing as mp
 
 import cupy
 import cupy.cuda.nccl as nccl
+import numpy as np
+import pytest
 
-from ...tests.core import require_unix
+from .. import xoscar_cupy as xc
 
 
 def worker_allreduce(rank, nccl_id, device_id):
-    from .. import xoscar_cupy as xc
-
     cupy.cuda.Device(device_id).use()
 
     context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
@@ -34,16 +34,265 @@ def worker_allreduce(rank, nccl_id, device_id):
     cupy.testing.assert_array_equal(recvbuf, cupy.array(sendbuf * 2))
 
 
-@require_unix
-def test_allreduce():
+def worker_allgather(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+    sendbuf = cupy.array([[1, 2, 3], [1, 2, 3]], dtype=cupy.float32)
+    recvbuf = cupy.zeros([2] + list(sendbuf.shape), dtype=cupy.float32)
+
+    xc.allgather(context, sendbuf, recvbuf)
+    cupy.testing.assert_array_equal(recvbuf, cupy.array([sendbuf] * 2))
+
+
+def worker_reduce(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+    sendbuf = cupy.array([[1, 2, 3], [1, 2, 3]], dtype=cupy.float32)
+    recvbuf = cupy.zeros_like(sendbuf, dtype=cupy.float32)
+    op = xc.ReduceOp.SUM
+    root = 0
+
+    xc.reduce(context, sendbuf, recvbuf, root, op)
+    if rank == root:
+        cupy.testing.assert_array_equal(
+            recvbuf,
+            cupy.array(
+                [
+                    [
+                        2.0,
+                        4.0,
+                        6.0,
+                    ],
+                    [2.0, 4.0, 6.0],
+                ]
+            ),
+        )
+    else:
+        cupy.testing.assert_array_equal(
+            recvbuf, cupy.zeros_like(sendbuf, dtype=cupy.float32)
+        )
+
+
+def worker_broadcast(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+
+    if rank == 0:
+        sendbuf = cupy.array([[1, 2, 3], [1, 2, 3]], dtype=cupy.float32)
+    else:
+        sendbuf = cupy.zeros((2, 3), dtype=cupy.float32)
+
+    recvbuf = cupy.zeros_like(sendbuf, dtype=cupy.float32)
+    root = 0
+
+    xc.broadcast(context, sendbuf, recvbuf, root)
+
+    cupy.testing.assert_array_equal(
+        recvbuf, cupy.array([[1, 2, 3], [1, 2, 3]], dtype=cupy.float32)
+    )
+
+
+def worker_scatter(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+
+    sendbuf = cupy.array([1, 2, 3, 4, 5, 6], dtype=cupy.float32)
+    recvbuf = cupy.array([0, 0, 0], dtype=cupy.float32)
+    root = 0
+
+    xc.scatter(context, sendbuf, recvbuf, root)
+
+    if rank == 0:
+        cupy.testing.assert_array_equal(recvbuf, cupy.array([1.0, 2.0, 3.0]))
+    elif rank == 1:
+        cupy.testing.assert_array_equal(recvbuf, cupy.array([4.0, 5.0, 6.0]))
+
+
+def worker_gather(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+
+    if rank == 0:
+        sendbuf = cupy.array([1, 2, 3], dtype=cupy.float32)
+    else:
+        sendbuf = cupy.array([4, 5, 6], dtype=cupy.float32)
+
+    recvbuf = cupy.array([0, 0, 0, 0, 0, 0], dtype=cupy.float32)
+    root = 0
+
+    xc.gather(context, sendbuf, recvbuf, root)
+
+    if rank == 0:
+        cupy.testing.assert_array_equal(
+            recvbuf, cupy.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        )
+
+
+def worker_reduce_scatter(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+
+    sendbuf = cupy.array([1, 2, 3, 4], dtype=cupy.float32)
+    recvbuf = cupy.array([0, 0], dtype=cupy.float32)
+    op = xc.ReduceOp.SUM
+
+    xc.reduce_scatter(context, sendbuf, recvbuf, op)
+
+    if rank == 0:
+        cupy.testing.assert_array_equal(recvbuf, cupy.array([2.0, 4.0]))
+    elif rank == 1:
+        cupy.testing.assert_array_equal(recvbuf, cupy.array([6.0, 8.0]))
+
+
+def worker_all_to_all(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+
+    if rank == 0:
+        sendbuf = cupy.array([[1, 2], [3, 4]], dtype=cupy.float32)
+    else:
+        sendbuf = cupy.array([[2, 4], [6, 8]], dtype=cupy.float32)
+    recvbuf = cupy.zeros((2, 2), dtype=cupy.float32)
+
+    xc.all_to_all(context, sendbuf, recvbuf)
+
+    if rank == 0:
+        cupy.testing.assert_array_equal(recvbuf, cupy.array([[1.0, 2.0], [2.0, 4.0]]))
+    elif rank == 1:
+        cupy.testing.assert_array_equal(recvbuf, cupy.array([[3.0, 4.0], [6.0, 8.0]]))
+
+
+def worker_barrier(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+    sendbuf = cupy.array([[1, 2, 3], [1, 2, 3]], dtype=cupy.float32)
+    recvbuf = cupy.zeros_like(sendbuf, dtype=cupy.float32)
+    op = xc.ReduceOp.SUM
+
+    xc.allreduce(context, sendbuf, recvbuf, op)
+    xc.barrier(context)
+
+    cupy.testing.assert_array_equal(recvbuf, cupy.array(sendbuf * 2))
+
+
+def test_scatter_buffer(rank, nccl_id, device_id):
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+
+    with pytest.raises(
+        ValueError,
+        match="Buffer size is not exactly divisible by the number of devices",
+    ):
+        not_divisible_buffer = cupy.array([1, 2, 3], dtype=cupy.float32)
+        xc.scatter_buffer(context, not_divisible_buffer)
+
+    with pytest.raises(
+        ValueError,
+        match="Buffer size is not exactly divisible by the number of devices",
+    ):
+        not_divisible_buffer = cupy.array([[1, 2, 3, 4]], dtype=cupy.float32)
+        xc.scatter_buffer(context, not_divisible_buffer)
+
+    buffer = cupy.array([1, 2, 3, 4], dtype=cupy.float32)
+    buffer_chunks = xc.scatter_buffer(context, buffer)
+    assert len(buffer_chunks) == 2
+    cupy.testing.assert_array_equal(buffer_chunks[0], cupy.array([1, 2]))
+    cupy.testing.assert_array_equal(buffer_chunks[1], cupy.array([3, 4]))
+
+    buffer = cupy.array([[1, 2], [3, 4]], dtype=cupy.float32)
+    buffer_chunks = xc.scatter_buffer(context, buffer)
+    assert len(buffer_chunks) == 2
+    cupy.testing.assert_array_equal(buffer_chunks[0], cupy.array([[1, 2]]))
+    cupy.testing.assert_array_equal(buffer_chunks[1], cupy.array([[3, 4]]))
+
+    buffer = cupy.array([[1], [2], [3], [4]], dtype=cupy.float32)
+    buffer_chunks = xc.scatter_buffer(context, buffer)
+    assert len(buffer_chunks) == 2
+    cupy.testing.assert_array_equal(buffer_chunks[0], cupy.array([[1], [2]]))
+    cupy.testing.assert_array_equal(buffer_chunks[1], cupy.array([[3], [4]]))
+
+
+def test_get_buffer_ptr():
+    import numpy as np
+
+    buffer = cupy.array([1, 2, 3], dtype=cupy.float32)
+
+    ptr = xc.get_buffer_ptr(buffer)
+    assert isinstance(ptr, int)
+    assert ptr == buffer.data.ptr
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        list_buffer = [1, 2, 3]
+        xc.get_buffer_ptr(list_buffer)
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        np_buffer = np.array([1, 2, 3])
+        xc.get_buffer_ptr(np_buffer)
+
+
+def test_get_nccl_buffer_dtype():
+    import numpy as np
+
+    CUPY_NCCL_DTYPE_MAP = {
+        cupy.uint8: nccl.NCCL_UINT8,
+        cupy.uint32: nccl.NCCL_UINT32,
+        cupy.uint64: nccl.NCCL_UINT64,
+        cupy.int8: nccl.NCCL_INT8,
+        cupy.int32: nccl.NCCL_INT32,
+        cupy.int64: nccl.NCCL_INT64,
+        cupy.half: nccl.NCCL_HALF,
+        cupy.float16: nccl.NCCL_FLOAT16,
+        cupy.float32: nccl.NCCL_FLOAT32,
+        cupy.float64: nccl.NCCL_FLOAT64,
+        cupy.double: nccl.NCCL_DOUBLE,
+    }
+
+    for cupy_dtype in CUPY_NCCL_DTYPE_MAP:
+        buffer = cupy.array([1, 2, 3], dtype=cupy_dtype)
+        assert xc.get_nccl_buffer_dtype(buffer) == CUPY_NCCL_DTYPE_MAP[cupy_dtype]
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        list_buffer = [1, 2, 3]
+        xc.get_nccl_buffer_dtype(list_buffer)
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        np_buffer = np.array([1, 2, 3])
+        xc.get_nccl_buffer_dtype(np_buffer)
+
+
+@pytest.mark.parametrize(
+    "worker_func",
+    [
+        worker_gather,
+        worker_all_to_all,
+        worker_allgather,
+        worker_allreduce,
+        worker_broadcast,
+        worker_reduce,
+        worker_reduce_scatter,
+        worker_scatter,
+        worker_barrier,
+        test_scatter_buffer,
+    ],
+)
+def test_driver(worker_func):
     mp.set_start_method("spawn")
 
     nccl_id = nccl.get_unique_id()
     device_id = [0, 1]
 
-    process1 = mp.Process(target=worker_allreduce, args=(0, nccl_id, device_id[0]))
+    process1 = mp.Process(target=worker_func, args=(0, nccl_id, device_id[0]))
     process1.start()
-    process2 = mp.Process(target=worker_allreduce, args=(1, nccl_id, device_id[1]))
+    process2 = mp.Process(target=worker_func, args=(1, nccl_id, device_id[1]))
     process2.start()
 
     process1.join()
@@ -51,3 +300,62 @@ def test_allreduce():
 
     assert process1.exitcode == 0, "Process 1 encountered an error."
     assert process2.exitcode == 0, "Process 2 encountered an error."
+
+
+def test_get_buffer_ptr():
+    buffer = cupy.array([1, 2, 3], dtype=cupy.float32)
+
+    ptr = xc.get_buffer_ptr(buffer)
+    assert isinstance(ptr, int)
+    assert ptr == buffer.data.ptr
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        list_buffer = [1, 2, 3]
+        xc.get_buffer_ptr(list_buffer)
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        np_buffer = np.array([1, 2, 3])
+        xc.get_buffer_ptr(np_buffer)
+
+
+def test_get_buffer_n_elements():
+    buffer = cupy.array([1, 2, 3], dtype=cupy.float32)
+
+    n = xc.get_buffer_n_elements(buffer)
+    assert n == buffer.size
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        list_buffer = [1, 2, 3]
+        xc.get_buffer_n_elements(list_buffer)
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        np_buffer = np.array([1, 2, 3])
+        xc.get_buffer_n_elements(np_buffer)
+
+
+def test_get_nccl_buffer_dtype():
+    CUPY_NCCL_DTYPE_MAP = {
+        cupy.uint8: nccl.NCCL_UINT8,
+        cupy.uint32: nccl.NCCL_UINT32,
+        cupy.uint64: nccl.NCCL_UINT64,
+        cupy.int8: nccl.NCCL_INT8,
+        cupy.int32: nccl.NCCL_INT32,
+        cupy.int64: nccl.NCCL_INT64,
+        cupy.half: nccl.NCCL_HALF,
+        cupy.float16: nccl.NCCL_FLOAT16,
+        cupy.float32: nccl.NCCL_FLOAT32,
+        cupy.float64: nccl.NCCL_FLOAT64,
+        cupy.double: nccl.NCCL_DOUBLE,
+    }
+
+    for cupy_dtype in CUPY_NCCL_DTYPE_MAP:
+        buffer = cupy.array([1, 2, 3], dtype=cupy_dtype)
+        assert xc.get_nccl_buffer_dtype(buffer) == CUPY_NCCL_DTYPE_MAP[cupy_dtype]
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        list_buffer = [1, 2, 3]
+        xc.get_nccl_buffer_dtype(list_buffer)
+
+    with pytest.raises(ValueError, match="Buffer type not supported"):
+        np_buffer = np.array([1, 2, 3])
+        xc.get_nccl_buffer_dtype(np_buffer)

--- a/python/xoscar/collective/tests/test_cupy.py
+++ b/python/xoscar/collective/tests/test_cupy.py
@@ -36,7 +36,7 @@ def worker_allreduce(rank, nccl_id, device_id):
 
 @require_unix
 def test_allreduce():
-    mp.set_start_method('spawn')
+    mp.set_start_method("spawn")
 
     nccl_id = nccl.get_unique_id()
     device_id = [0, 1]

--- a/python/xoscar/collective/tests/test_cupy.py
+++ b/python/xoscar/collective/tests/test_cupy.py
@@ -1,0 +1,53 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing as mp
+
+import cupy
+import cupy.cuda.nccl as nccl
+
+from ...tests.core import require_unix
+
+
+def worker_allreduce(rank, nccl_id, device_id):
+    from .. import xoscar_cupy as xc
+
+    cupy.cuda.Device(device_id).use()
+
+    context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
+    sendbuf = cupy.array([[1, 2, 3], [1, 2, 3]], dtype=cupy.float32)
+    recvbuf = cupy.zeros_like(sendbuf, dtype=cupy.float32)
+    op = xc.ReduceOp.SUM
+
+    xc.allreduce(context, sendbuf, recvbuf, op)
+    cupy.testing.assert_array_equal(recvbuf, cupy.array(sendbuf * 2))
+
+
+@require_unix
+def test_allreduce():
+    mp.set_start_method('spawn')
+
+    nccl_id = nccl.get_unique_id()
+    device_id = [0, 1]
+
+    process1 = mp.Process(target=worker_allreduce, args=(0, nccl_id, device_id[0]))
+    process1.start()
+    process2 = mp.Process(target=worker_allreduce, args=(1, nccl_id, device_id[1]))
+    process2.start()
+
+    process1.join()
+    process2.join()
+
+    assert process1.exitcode == 0, "Process 1 encountered an error."
+    assert process2.exitcode == 0, "Process 2 encountered an error."

--- a/python/xoscar/collective/tests/test_cupy.py
+++ b/python/xoscar/collective/tests/test_cupy.py
@@ -21,6 +21,8 @@ import pytest
 
 from .. import xoscar_cupy as xc
 
+mp.set_start_method("spawn")
+
 
 def worker_allreduce(rank, nccl_id, device_id):
     cupy.cuda.Device(device_id).use()
@@ -183,7 +185,7 @@ def worker_barrier(rank, nccl_id, device_id):
     cupy.testing.assert_array_equal(recvbuf, cupy.array(sendbuf * 2))
 
 
-def test_scatter_buffer(rank, nccl_id, device_id):
+def worker_scatter_buffer(rank, nccl_id, device_id):
     cupy.cuda.Device(device_id).use()
 
     context = xc.Context(n_devices=2, nccl_unique_id=nccl_id, rank=rank)
@@ -233,12 +235,10 @@ def test_scatter_buffer(rank, nccl_id, device_id):
         worker_reduce_scatter,
         worker_scatter,
         worker_barrier,
-        test_scatter_buffer,
+        worker_scatter_buffer,
     ],
 )
 def test_driver(worker_func):
-    mp.set_start_method("spawn")
-
     nccl_id = nccl.get_unique_id()
     device_id = [0, 1]
 

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -1,0 +1,83 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import Optional, Tuple
+
+import cupy
+import cupy.cuda.nccl as nccl
+
+
+class ReduceOp(Enum):
+    SUM = nccl.NCCL_SUM
+    PRODUCT = nccl.NCCL_PROD
+    MIN = nccl.NCCL_MIN
+    MAX = nccl.NCCL_MAX
+
+
+NUMPY_NCCL_DTYPE_MAP = {
+    cupy.uint8: nccl.NCCL_UINT8,
+    cupy.uint32: nccl.NCCL_UINT32,
+    cupy.uint64: nccl.NCCL_UINT64,
+    cupy.int8: nccl.NCCL_INT8,
+    cupy.int32: nccl.NCCL_INT32,
+    cupy.int64: nccl.NCCL_INT64,
+    cupy.half: nccl.NCCL_HALF,
+    cupy.float16: nccl.NCCL_FLOAT16,
+    cupy.float32: nccl.NCCL_FLOAT32,
+    cupy.float64: nccl.NCCL_FLOAT64,
+    cupy.double: nccl.NCCL_DOUBLE
+}
+
+
+class Context:
+    def __init__(self, n_devices: int, nccl_unique_id: Tuple, rank: int):
+        self.communicator = nccl.NcclCommunicator(n_devices,nccl_unique_id, rank)
+
+
+def allreduce(
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
+    reduceop: Optional[ReduceOp] = ReduceOp.SUM,
+):
+    context.communicator.allReduce(
+        get_buffer_ptr(sendbuf),
+        get_buffer_ptr(recvbuf),
+        get_buffer_n_elements(sendbuf),
+        get_nccl_buffer_dtype(sendbuf),
+        reduceop.value,
+        cupy.cuda.Stream.null.ptr,
+    )
+
+
+def get_buffer_ptr(buffer):
+    if isinstance(buffer, cupy.ndarray):
+        return buffer.data.ptr
+
+    raise ValueError("Buffer type not supported")
+
+
+def get_buffer_n_elements(buffer):
+    if isinstance(buffer, (cupy.ndarray)):
+        return buffer.size
+
+    raise ValueError("Buffer type not supported")
+
+
+def get_nccl_buffer_dtype(buffer):
+    if isinstance(buffer, cupy.ndarray):
+        return NUMPY_NCCL_DTYPE_MAP[buffer.dtype.type]
+
+    raise ValueError("Unspported GPU buffer type")

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -153,8 +153,8 @@ def gather(
                 recv(context, temp_recv, peer)
                 buffs.append(temp_recv)
 
-        buffs = cupy.concatenate(buffs)
-        recvbuf[:] = buffs.reshape(recvbuf.shape)
+        cupy_buff = cupy.concatenate(buffs)
+        recvbuf[:] = cupy_buff.reshape(recvbuf.shape)
     else:
         send(context, sendbuf, root)
 
@@ -217,9 +217,9 @@ def reduce_scatter(
 def barrier(
     context: Context,
 ):
-    barrier_tensors = [None] * len(context.n_devices)
-    for i, d in enumerate(context.n_devices):
-        with cupy.cuda.Device(d):
+    barrier_tensors = [None] * context.n_devices
+    for i in range(context.n_devices):
+        with cupy.cuda.Device(i):
             barrier_tensors[i] = cupy.array([1])
     allreduce(context, barrier_tensors, barrier_tensors)
 

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -79,9 +79,9 @@ def allgather(
 
 
 def all_to_all(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    recvbuf: cupy.ndarray = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
 ):
     assert context.n_devices == sendbuf.shape[0]
 
@@ -95,17 +95,17 @@ def all_to_all(
                     temp_recv = sendbuf[i].copy()
                     recv(context, temp_recv, peer)
                     buf_i.append(temp_recv)
-            buf_i = cupy.concatenate(buf_i)
-            recvbuf[:] = buf_i.reshape(recvbuf.shape)
+            cupy_buf_i = cupy.concatenate(buf_i)
+            recvbuf[:] = cupy_buf_i.reshape(recvbuf.shape)
         else:
             send(context, sendbuf[i], i)
 
 
 def reduce(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    recvbuf: cupy.ndarray = None,
-    root: int = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
+    root: Optional[int] = None,
     op: Optional[ReduceOp] = ReduceOp.SUM,
 ):
     context.communicator.reduce(
@@ -120,10 +120,10 @@ def reduce(
 
 
 def scatter(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    recvbuf: cupy.ndarray = None,
-    root: int = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
+    root: Optional[int] = None,
 ):
     if context.rank == root:
         # make sendbuf equally scattered into context.n_devices chunks
@@ -138,10 +138,10 @@ def scatter(
 
 
 def gather(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    recvbuf: cupy.ndarray = None,
-    root: int = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
+    root: Optional[int] = None,
 ):
     if context.rank == root:
         buffs = []
@@ -160,9 +160,9 @@ def gather(
 
 
 def send(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    peer: int = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    peer: Optional[int] = None,
 ):
     context.communicator.send(
         get_buffer_ptr(sendbuf),
@@ -174,9 +174,9 @@ def send(
 
 
 def recv(
-    context: Context = None,
-    recvbuf: cupy.ndarray = None,
-    peer: int = None,
+    context: Optional[Context] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
+    peer: Optional[int] = None,
 ):
     context.communicator.recv(
         get_buffer_ptr(recvbuf),
@@ -188,10 +188,10 @@ def recv(
 
 
 def broadcast(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    recvbuf: cupy.ndarray = None,
-    root: int = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
+    root: Optional[int] = None,
 ):
     context.communicator.broadcast(
         get_buffer_ptr(sendbuf),
@@ -204,9 +204,9 @@ def broadcast(
 
 
 def reduce_scatter(
-    context: Context = None,
-    sendbuf: cupy.ndarray = None,
-    recvbuf: cupy.ndarray = None,
+    context: Optional[Context] = None,
+    sendbuf: Optional[cupy.ndarray] = None,
+    recvbuf: Optional[cupy.ndarray] = None,
     op: Optional[ReduceOp] = ReduceOp.SUM,
 ):
     reduce_recv = sendbuf.copy()
@@ -215,7 +215,7 @@ def reduce_scatter(
 
 
 def barrier(
-    context: Context = None,
+    context: Optional[Context] = None,
 ):
     barrier_tensors = [None] * len(context.n_devices)
     for i, d in enumerate(context.n_devices):

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -152,6 +152,7 @@ def gather(
                 temp_recv = sendbuf.copy()
                 recv(context, temp_recv, peer)
                 buffs.append(temp_recv)
+
         buffs = cupy.concatenate(buffs)
         recvbuf[:] = buffs.reshape(recvbuf.shape)
     else:

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -37,13 +37,13 @@ NUMPY_NCCL_DTYPE_MAP = {
     cupy.float16: nccl.NCCL_FLOAT16,
     cupy.float32: nccl.NCCL_FLOAT32,
     cupy.float64: nccl.NCCL_FLOAT64,
-    cupy.double: nccl.NCCL_DOUBLE
+    cupy.double: nccl.NCCL_DOUBLE,
 }
 
 
 class Context:
     def __init__(self, n_devices: int, nccl_unique_id: Tuple, rank: int):
-        self.communicator = nccl.NcclCommunicator(n_devices,nccl_unique_id, rank)
+        self.communicator = nccl.NcclCommunicator(n_devices, nccl_unique_id, rank)
 
 
 def allreduce(

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -217,7 +217,7 @@ def reduce_scatter(
 def barrier(
     context: Context,
 ):
-    barrier_tensors = [None] * context.n_devices
+    barrier_tensors = cupy.array([i for i in range(context.n_devices)], dtype=cupy.float32)
     for i in range(context.n_devices):
         with cupy.cuda.Device(i):
             barrier_tensors[i] = cupy.array([1])

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Tuple
 
 import cupy
 import cupy.cuda.nccl as nccl
@@ -49,10 +49,10 @@ class Context:
 
 
 def allreduce(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    op: Optional[ReduceOp] = ReduceOp.SUM,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
+    op: ReduceOp = ReduceOp.SUM,
 ):
     context.communicator.allReduce(
         get_buffer_ptr(sendbuf),
@@ -65,9 +65,9 @@ def allreduce(
 
 
 def allgather(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
 ):
     context.communicator.allGather(
         get_buffer_ptr(sendbuf),
@@ -79,9 +79,9 @@ def allgather(
 
 
 def all_to_all(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
 ):
     assert context.n_devices == sendbuf.shape[0]
 
@@ -102,11 +102,11 @@ def all_to_all(
 
 
 def reduce(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    root: Optional[int] = None,
-    op: Optional[ReduceOp] = ReduceOp.SUM,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
+    root: int,
+    op: ReduceOp = ReduceOp.SUM,
 ):
     context.communicator.reduce(
         get_buffer_ptr(sendbuf),
@@ -120,10 +120,10 @@ def reduce(
 
 
 def scatter(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    root: Optional[int] = None,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
+    root: int,
 ):
     if context.rank == root:
         # make sendbuf equally scattered into context.n_devices chunks
@@ -138,10 +138,10 @@ def scatter(
 
 
 def gather(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    root: Optional[int] = None,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
+    root: int,
 ):
     if context.rank == root:
         buffs = []
@@ -160,9 +160,9 @@ def gather(
 
 
 def send(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    peer: Optional[int] = None,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    peer: int,
 ):
     context.communicator.send(
         get_buffer_ptr(sendbuf),
@@ -174,9 +174,9 @@ def send(
 
 
 def recv(
-    context: Optional[Context] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    peer: Optional[int] = None,
+    context: Context,
+    recvbuf: cupy.ndarray,
+    peer: int,
 ):
     context.communicator.recv(
         get_buffer_ptr(recvbuf),
@@ -188,10 +188,10 @@ def recv(
 
 
 def broadcast(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    root: Optional[int] = None,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
+    root: int,
 ):
     context.communicator.broadcast(
         get_buffer_ptr(sendbuf),
@@ -204,10 +204,10 @@ def broadcast(
 
 
 def reduce_scatter(
-    context: Optional[Context] = None,
-    sendbuf: Optional[cupy.ndarray] = None,
-    recvbuf: Optional[cupy.ndarray] = None,
-    op: Optional[ReduceOp] = ReduceOp.SUM,
+    context: Context,
+    sendbuf: cupy.ndarray,
+    recvbuf: cupy.ndarray,
+    op: ReduceOp = ReduceOp.SUM,
 ):
     reduce_recv = sendbuf.copy()
     reduce(context, sendbuf, reduce_recv, 0, op)
@@ -215,7 +215,7 @@ def reduce_scatter(
 
 
 def barrier(
-    context: Optional[Context] = None,
+    context: Context,
 ):
     barrier_tensors = [None] * len(context.n_devices)
     for i, d in enumerate(context.n_devices):

--- a/python/xoscar/collective/xoscar_cupy.py
+++ b/python/xoscar/collective/xoscar_cupy.py
@@ -217,10 +217,7 @@ def reduce_scatter(
 def barrier(
     context: Context,
 ):
-    barrier_tensors = cupy.array([i for i in range(context.n_devices)], dtype=cupy.float32)
-    for i in range(context.n_devices):
-        with cupy.cuda.Device(i):
-            barrier_tensors[i] = cupy.array([1])
+    barrier_tensors = cupy.array([1])
     allreduce(context, barrier_tensors, barrier_tensors)
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Add GPU collective communication using cupy NcclCommunicator (similar to alpa: https://github.com/alpa-projects/alpa/blob/main/alpa/collective/collective_group/nccl_collective_group.py but tried to implement missing apis). Will implement a process group class once #46  is finished.

test cases are similar to pygloo test cases: https://github.com/xorbitsai/xoscar/blob/main/python/xoscar/collective/tests/test_pygloo.py

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Related #22 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
