### PR TITLE
ENH: Environment variable to set the Xoscar temp directory.

### DIFF
--- a/python/xoscar/constants.py
+++ b/python/xoscar/constants.py
@@ -15,7 +15,7 @@
 import os
 from pathlib import Path
 
-XOSCAR_TEMP_DIR = Path.home() / ".xoscar"
+XOSCAR_TEMP_DIR = os.getenv('XOSCAR_DIR', Path.home()) / ".xoscar"
 
 # unix socket.
 XOSCAR_UNIX_SOCKET_DIR = os.path.join(XOSCAR_TEMP_DIR, "socket")

--- a/python/xoscar/constants.py
+++ b/python/xoscar/constants.py
@@ -15,7 +15,7 @@
 import os
 from pathlib import Path
 
-XOSCAR_TEMP_DIR = Path(os.getenv('XOSCAR_DIR', Path.home())) / ".xoscar"
+XOSCAR_TEMP_DIR = Path(os.getenv("XOSCAR_DIR", Path.home())) / ".xoscar"
 
 # unix socket.
 XOSCAR_UNIX_SOCKET_DIR = XOSCAR_TEMP_DIR / "socket"

--- a/python/xoscar/constants.py
+++ b/python/xoscar/constants.py
@@ -15,7 +15,7 @@
 import os
 from pathlib import Path
 
-XOSCAR_TEMP_DIR = os.getenv('XOSCAR_DIR', Path.home()) / ".xoscar"
+XOSCAR_TEMP_DIR = Path(os.getenv('XOSCAR_DIR', Path.home())) / ".xoscar"
 
 # unix socket.
-XOSCAR_UNIX_SOCKET_DIR = os.path.join(XOSCAR_TEMP_DIR, "socket")
+XOSCAR_UNIX_SOCKET_DIR = XOSCAR_TEMP_DIR / "socket"


### PR DESCRIPTION
Following the discussion on my question on the slack channel, this PR adds the ability to set an environment variable for the xoscar temp directory. I've just called it `XOSCAR_DIR` for now. If the variable is not set the old behaviour of using the home directory is maintened. 