### PR TITLE
ENH: Remove StatelessActor

### DIFF
--- a/python/xoscar/__init__.py
+++ b/python/xoscar/__init__.py
@@ -27,7 +27,6 @@ from .api import (
     file_object_ref,
     copy_to,
     Actor,
-    StatelessActor,
     create_actor_pool,
     setup_cluster,
     wait_actor_pool_recovered,

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections import defaultdict
 from numbers import Number
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
@@ -23,7 +24,7 @@ from urllib.parse import urlparse
 from .aio import AioFileObject
 from .backend import get_backend
 from .context import get_context
-from .core import ActorRef, BufferRef, FileObjectRef, _Actor, _StatelessActor
+from .core import ActorRef, BufferRef, FileObjectRef, _Actor
 
 if TYPE_CHECKING:
     from .backends.config import ActorPoolConfig
@@ -307,11 +308,9 @@ class AsyncActorMixin:
 
 
 class Actor(AsyncActorMixin, _Actor):
-    pass
-
-
-class StatelessActor(AsyncActorMixin, _StatelessActor):
-    pass
+    # Guard all the methods with an instance of __xoscar_lock_type__
+    # Lock free if the __xoscar_lock_type__ is None.
+    __xoscar_lock_type__ = asyncio.locks.Lock
 
 
 _actor_implementation: Dict[Type[Actor], Type[Actor]] = dict()

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -310,7 +310,7 @@ class AsyncActorMixin:
 class Actor(AsyncActorMixin, _Actor):
     # Guard all the methods with an instance of __xoscar_lock_type__
     # Lock free if the __xoscar_lock_type__ is None.
-    __xoscar_lock_type__: Optional[type(asyncio.locks.Lock)] = asyncio.locks.Lock
+    __xoscar_lock_type__: Optional[type[asyncio.locks.Lock]] = asyncio.locks.Lock
 
 
 _actor_implementation: Dict[Type[Actor], Type[Actor]] = dict()

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -310,7 +310,7 @@ class AsyncActorMixin:
 class Actor(AsyncActorMixin, _Actor):
     # Guard all the methods with an instance of __xoscar_lock_type__
     # Lock free if the __xoscar_lock_type__ is None.
-    __xoscar_lock_type__ = asyncio.locks.Lock
+    __xoscar_lock_type__: Optional[type(asyncio.locks.Lock)] = asyncio.locks.Lock
 
 
 _actor_implementation: Dict[Type[Actor], Type[Actor]] = dict()

--- a/python/xoscar/backends/indigen/tests/test_indigen_actor_context.py
+++ b/python/xoscar/backends/indigen/tests/test_indigen_actor_context.py
@@ -157,7 +157,9 @@ class CreateDestroyActor(mo.Actor):
         return message
 
 
-class ResourceLockActor(mo.StatelessActor):
+class ResourceLockActor(mo.Actor):
+    __xoscar_lock_type__ = None
+
     def __init__(self, count=1):
         self._sem = asyncio.Semaphore(count)
         self._requests = deque()

--- a/python/xoscar/core.pyx
+++ b/python/xoscar/core.pyx
@@ -545,14 +545,6 @@ cdef class _BaseActor:
             raise ex
 
 
-# The @cython.binding(True) is for ray getting members.
-# The value is True by default after cython >= 3.0.0
-@cython.binding(True)
-cdef class _Actor(_BaseActor):
-    def _create_lock(self):
-        return asyncio.locks.Lock()
-
-
 cdef class _FakeLock:
     async def __aenter__(self):
         pass
@@ -564,9 +556,12 @@ cdef class _FakeLock:
 # The @cython.binding(True) is for ray getting members.
 # The value is True by default after cython >= 3.0.0
 @cython.binding(True)
-cdef class _StatelessActor(_BaseActor):
+cdef class _Actor(_BaseActor):
     def _create_lock(self):
-        return _FakeLock()
+        lock_type = self.__xoscar_lock_type__
+        if lock_type is None:
+            return _FakeLock()
+        return lock_type()
 
 
 cdef class BufferRef:


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

The `StatelessActor` is ambiguity, remove it and use a class attribute `__xoscar_lock_type__` instead.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/xorbitsai/xoscar/issues/67

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
