### PR TITLE
FEAT: make it easy to define generator methods in Actor

### DIFF
--- a/python/xoscar/__init__.py
+++ b/python/xoscar/__init__.py
@@ -32,6 +32,7 @@ from .api import (
     setup_cluster,
     wait_actor_pool_recovered,
     get_pool_config,
+    generator,
 )
 from .backends import allocate_strategy
 from .backends.pool import MainActorPoolType

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -437,13 +437,13 @@ class AsyncActorMixin:
 
 
 def generator(func):
-    async def wapper(obj, *args, **kwargs):
+    async def wrapper(obj, *args, **kwargs):
         gen_uid = uuid.uuid1().hex
         obj._generators[gen_uid] = func(obj, *args, **kwargs)
         return IteratorWrapper(gen_uid, obj.address, obj.uid)
 
     if inspect.isgeneratorfunction(func) or inspect.isasyncgenfunction(func):
-        return wapper
+        return wrapper
     else:
         return func
 

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -342,7 +342,8 @@ class AsyncActorMixin:
         except KeyError:
             return super().__new__(cls, *args, **kwargs)
 
-    def __init__(self) -> None:
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
         self._generators: Dict[str, IteratorWrapper] = {}
 
     async def __post_create__(self):

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -15,10 +15,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections import defaultdict
+import inspect
 from numbers import Number
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, TypeVar, Generic
 from urllib.parse import urlparse
+import uuid
 
 from .aio import AioFileObject
 from .backend import get_backend
@@ -271,6 +274,40 @@ def setup_cluster(address_to_resources: Dict[str, Dict[str, Number]]):
         get_backend(scheme).get_driver_cls().setup_cluster(address_resources)
 
 
+T = TypeVar("T")
+
+class IteratorWrapper(Generic[T]):
+    def __init__(self, uid: str, actor_addr: str, actor_uid: str):
+        self._uid = uid
+        self._actor_addr = actor_addr
+        self._actor_uid = actor_uid
+        self._actor_ref = None
+
+    async def destroy(self):
+        if self._actor_ref is None:
+            self._actor_ref = await actor_ref(
+                address=self._actor_addr, uid=self._actor_uid
+            )
+        assert self._actor_ref is not None
+        return await self._actor_ref.destroy_generator(self._uid)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> T:
+        if self._actor_ref is None:
+            self._actor_ref = await actor_ref(
+                address=self._actor_addr, uid=self._actor_uid
+            )
+        try:
+            assert self._actor_ref is not None
+            return await self._actor_ref.next(self._uid)
+        except Exception as e:
+            if "StopIteration" in str(e):
+                raise StopAsyncIteration
+            else:
+                raise
+
 class AsyncActorMixin:
     @classmethod
     def default_uid(cls):
@@ -281,6 +318,9 @@ class AsyncActorMixin:
             return _actor_implementation[cls](*args, **kwargs)
         except KeyError:
             return super().__new__(cls, *args, **kwargs)
+
+    def __init__(self) -> None:
+        self._generators: Dict[str, IteratorWrapper] = {}
 
     async def __post_create__(self):
         """
@@ -304,6 +344,55 @@ class AsyncActorMixin:
             Message shall be (method_name,) + args + (kwargs,)
         """
         return await super().__on_receive__(message)  # type: ignore
+
+    async def next(
+        self, generator_uid: str
+    ) -> Any:
+        def _wrapper():
+            try:
+                return next(gen)
+            except StopIteration:
+                return stop
+
+        async def _async_wrapper():
+            try:
+                # anext is only available for Python >= 3.10
+                return await gen.__anext__()  # noqa: F821
+            except StopAsyncIteration:
+                return stop
+
+        if gen := self._generators.get(generator_uid):
+            stop = object()
+            if inspect.isgenerator(gen):
+                # to_thread is only available for Python >= 3.9
+                if hasattr(asyncio, "to_thread"):
+                    r = await asyncio.to_thread(_wrapper)
+                else:
+                    r = await asyncio.get_event_loop().run_in_executor(None, _wrapper)
+            elif inspect.isasyncgen(gen):
+                r = await asyncio.create_task(_async_wrapper())
+            if r is stop:
+                await self.destroy_generator(generator_uid)
+                raise Exception("StopIteration")
+            else:
+                return r
+        else:
+            raise RuntimeError(f"no iterator with id: {generator_uid}")
+
+    async def destroy_generator(self, generator_uid: str):
+        return self._generators.pop(generator_uid, None)
+
+
+def generator(func):
+    async def wapper(obj, *args, **kwargs):
+        gen_uid = uuid.uuid1().hex
+        obj._generators[gen_uid] = func(obj, *args, **kwargs)
+        return IteratorWrapper(gen_uid, obj.address, obj.uid)
+
+    if inspect.isgeneratorfunction(func) or inspect.isasyncgenfunction(func):
+        return wapper
+    else:
+        return func
 
 
 class Actor(AsyncActorMixin, _Actor):

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -1,3 +1,17 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 import time
 

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -1,0 +1,126 @@
+import asyncio
+import time
+
+import pytest
+
+import xoscar as xo
+
+address = "127.0.0.1:12347"
+
+
+class WorkerActor(xo.StatelessActor):
+    @xo.generator
+    def chat(self):
+        for x in "hello oscar by sync":
+            yield x
+            time.sleep(0.1)
+
+    @xo.generator
+    async def achat(self):
+        for x in "hello oscar by async":
+            yield x
+            await asyncio.sleep(0.1)
+
+    @classmethod
+    def uid(cls):
+        return "worker"
+
+
+class SupervisorActor(xo.StatelessActor):
+    def get_all_generators(self):
+        return list(self._generators.keys())
+
+    @xo.generator
+    async def chat(self):
+        worker_actor: xo.ActorRef["WorkerActor"] = await xo.actor_ref(
+            address=address, uid=WorkerActor.uid()
+        )
+        yield "sync"
+        async for x in await worker_actor.chat():  # this is much confused. I will suggest use async generators only.
+            yield x
+
+        yield "async"
+        async for x in await worker_actor.achat():
+            yield x
+
+    @xo.generator
+    async def with_exception(self):
+        yield 1
+        raise Exception("intent raise")
+        yield 2
+
+    @classmethod
+    def uid(cls):
+        return "supervisor"
+
+
+async def test_generator():
+    pool = await xo.create_actor_pool(address, 2)
+    await xo.create_actor(WorkerActor, address=address, uid=WorkerActor.uid())
+    superivsor_actor = await xo.create_actor(
+        SupervisorActor, address=address, uid=SupervisorActor.uid()
+    )
+
+    all_gen = await superivsor_actor.get_all_generators()
+    assert len(all_gen) == 0
+    output = []
+    async for x in await superivsor_actor.chat():
+        all_gen = await superivsor_actor.get_all_generators()
+        assert len(all_gen) == 1
+        output.append(x)
+    all_gen = await superivsor_actor.get_all_generators()
+    assert len(all_gen) == 0
+    assert output == [
+        "sync",
+        "h",
+        "e",
+        "l",
+        "l",
+        "o",
+        " ",
+        "o",
+        "s",
+        "c",
+        "a",
+        "r",
+        " ",
+        "b",
+        "y",
+        " ",
+        "s",
+        "y",
+        "n",
+        "c",
+        "async",
+        "h",
+        "e",
+        "l",
+        "l",
+        "o",
+        " ",
+        "o",
+        "s",
+        "c",
+        "a",
+        "r",
+        " ",
+        "b",
+        "y",
+        " ",
+        "a",
+        "s",
+        "y",
+        "n",
+        "c",
+    ]
+
+    with pytest.raises(Exception, match="intent"):
+        async for _ in await superivsor_actor.with_exception():
+            pass
+    all_gen = await superivsor_actor.get_all_generators()
+    assert len(all_gen) == 0
+
+    await asyncio.create_task(superivsor_actor.with_exception())
+    await asyncio.sleep(0)
+    all_gen = await superivsor_actor.get_all_generators()
+    assert len(all_gen) == 0

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -55,7 +55,7 @@ class SupervisorActor(xo.StatelessActor):
 
 
 async def test_generator():
-    pool = await xo.create_actor_pool(address, 2)
+    await xo.create_actor_pool(address, 2)
     await xo.create_actor(WorkerActor, address=address, uid=WorkerActor.uid())
     superivsor_actor = await xo.create_actor(
         SupervisorActor, address=address, uid=SupervisorActor.uid()


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Generators can not be transferred directly between actors, users must wrap it to a iterator object referencing to the code of xinference ModelActor.
But the wrapping codes are complex and need to rewrite them in every generators.

This PR provides a decorator: xo.generator, users can define generators as usual in a simple way:
```
import asyncio
import time
import xoscar as xo


address = "127.0.0.1:8000"

class WorkerActor(xo.StatelessActor):
    @xo.generator
    def chat(self):
        for x in "hello oscar by sync":
            yield x
            time.sleep(0.1)

    @xo.generator
    async def achat(self):
        for x in "hello oscar by async":
            yield x
            await asyncio.sleep(0.1)

    @classmethod
    def uid(cls):
        return "worker"


class SupervisorActor(xo.StatelessActor):
    @xo.generator
    async def chat(self):
        worker_actor: xo.ActorRef["WorkerActor"] = await xo.actor_ref(address=address, uid=WorkerActor.uid())
        yield "\nsync"
        async for x in await worker_actor.chat(): # this is much confused. I will suggest use async generators only.
            yield x
        
        yield "\nasync"
        async for x in await worker_actor.achat():
            yield x

    @classmethod
    def uid(cls):
        return "supervisor"


async def main():
    pool = await xo.create_actor_pool(address, 2)
    await xo.create_actor(WorkerActor, address=address, uid=WorkerActor.uid())
    superivsor_actor = await xo.create_actor(SupervisorActor, address=address, uid=SupervisorActor.uid())

    async for x in await superivsor_actor.chat():
        print(x)

    await pool.join()


asyncio.run(main())

```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
