### PR TITLE
FEAT: generator support normal function

### DIFF
--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -19,8 +19,6 @@ import asyncio
 import functools
 import inspect
 import logging
-import os
-import sys
 import threading
 import uuid
 from collections import defaultdict

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -435,6 +435,7 @@ class AsyncActorMixin:
 def generator(func):
     need_to_thread = not asyncio.iscoroutinefunction(func)
 
+    @functools.wraps(func)
     async def _wrapper(self, *args, **kwargs):
         if need_to_thread:
             r = await asyncio.to_thread(func, self, *args, **kwargs)

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -424,7 +424,7 @@ class AsyncActorMixin:
                     )
             except Exception as e:
                 logger.exception(
-                    f"Destory generator {generator_uid} due to an error encountered."
+                    f"Destroy generator {generator_uid} due to an error encountered."
                 )
                 await self.__xoscar_destroy_generator__(generator_uid)
                 del gen  # Avoid exception hold generator reference.

--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -16,9 +16,9 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import threading
-import functools
 import uuid
 from collections import defaultdict
 from numbers import Number

--- a/python/xoscar/core.pyx
+++ b/python/xoscar/core.pyx
@@ -127,7 +127,7 @@ cdef class ActorRef:
         return create_actor_ref, (self.address, self.uid)
 
     def __getattr__(self, item):
-        if item.startswith('_'):
+        if item.startswith('_') and item not in ["__xoscar_next__", "__xoscar_destroy_generator__"]:
             return object.__getattribute__(self, item)
 
         try:

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import os
 import time
 
 import pytest

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import os
 import time
 
 import pytest
@@ -160,7 +161,8 @@ async def test_generator():
     all_gen = await superivsor_actor.get_all_generators()
     assert len(all_gen) == 0
 
-    await asyncio.create_task(superivsor_actor.with_exception())
+    r = await superivsor_actor.with_exception()
+    del r
     await asyncio.sleep(0)
     all_gen = await superivsor_actor.get_all_generators()
     assert len(all_gen) == 0

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -63,6 +63,32 @@ class SupervisorActor(xo.StatelessActor):
         raise Exception("intent raise")
         yield 2
 
+    @xo.generator
+    async def mix_gen(self, v):
+        if v == 1:
+            return self._gen()
+        elif v == 2:
+            return self._gen2()
+        else:
+            return 0
+
+    @xo.generator
+    def mix_gen2(self, v):
+        if v == 1:
+            return self._gen()
+        elif v == 2:
+            return self._gen2()
+        else:
+            return 0
+
+    def _gen(self):
+        for x in range(3):
+            yield x
+
+    async def _gen2(self):
+        for x in range(3):
+            yield x
+
     @classmethod
     def uid(cls):
         return "supervisor"
@@ -138,3 +164,14 @@ async def test_generator():
     await asyncio.sleep(0)
     all_gen = await superivsor_actor.get_all_generators()
     assert len(all_gen) == 0
+
+    for f in [superivsor_actor.mix_gen, superivsor_actor.mix_gen2]:
+        out = []
+        async for x in await f(1):
+            out.append(x)
+        assert out == [0, 1, 2]
+        out = []
+        async for x in await f(2):
+            out.append(x)
+        assert out == [0, 1, 2]
+        assert 0 == await f(0)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

- If a normal function is decorated by `xo.generator`, then the function will be run by `to_threads`.
- Regardless of whether a function is decorated by `xo.generator` returns a generator or an async generator or a value, the function should works as expected.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
