### PR TITLE
BUG: Fix getstate compatibility

### DIFF
--- a/python/xoscar/api.py
+++ b/python/xoscar/api.py
@@ -325,7 +325,7 @@ class IteratorWrapper(Generic[T]):
 
     def __getstate__(self):
         # Transfer gc destroy during serialization.
-        state = dict(**super().__getstate__())
+        state = self.__dict__.copy()
         state["_gc_destroy"] = True
         self._gc_destroy = False
         return state

--- a/python/xoscar/tests/test_generator.py
+++ b/python/xoscar/tests/test_generator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import pickle
 import time
 
 import pytest
@@ -161,6 +162,7 @@ async def test_generator():
     assert len(all_gen) == 0
 
     r = await superivsor_actor.with_exception()
+    pickle.loads(pickle.dumps(r))
     del r
     await asyncio.sleep(0)
     all_gen = await superivsor_actor.get_all_generators()


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

`super().__getstate__` is not availabe for Python < 3.11

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
