### PR TITLE
BLD: Fix macos build error

### DIFF
--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -36,14 +36,17 @@ jobs:
             arch: aarch64
             requires-python: ">=3.11,<3.12"
           - os: macos-latest
-            arch: arm64
-            requires-python: ">=3.9,<3.10"
+            arch: x86_64
+            requires-python: ">=3.8,<3.10"
           - os: macos-latest
-            arch: arm64
-            requires-python: ">=3.10,<3.11"
+            arch: x86_64
+            requires-python: ">=3.10,<3.12"
           - os: macos-latest
-            arch: arm64
-            requires-python: ">=3.11,<3.12"
+            arch: universal2
+            requires-python: ">=3.8,<3.10"
+          - os: macos-latest
+            arch: universal2
+            requires-python: ">=3.10,<3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '55 14 * * *'
+    - cron: '30 4 * * *'
   push:
     tags:
       - '*'

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '30 4 * * *'
+    - cron: '02 14 * * *'
   push:
     tags:
       - '*'

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '02 14 * * *'
+    - cron: '55 14 * * *'
   push:
     tags:
       - '*'
@@ -35,16 +35,16 @@ jobs:
           - os: ubuntu-latest
             arch: aarch64
             requires-python: ">=3.11,<3.12"
-          - os: macos-latest
+          - os: macos-12
             arch: x86_64
             requires-python: ">=3.8,<3.10"
-          - os: macos-latest
+          - os: macos-12
             arch: x86_64
             requires-python: ">=3.10,<3.12"
-          - os: macos-latest
+          - os: macos-12
             arch: universal2
             requires-python: ">=3.8,<3.10"
-          - os: macos-latest
+          - os: macos-12
             arch: universal2
             requires-python: ">=3.10,<3.12"
 


### PR DESCRIPTION
macos-latest now default uses arm64 rather than x86_64.  See: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Tested on my repo:

https://github.com/luweizheng/xoscar/actions/runs/9876596547/
