### PR TITLE
Enable create_actor_pool to use elastic ip

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -148,7 +148,7 @@ jobs:
       working-directory: ./python
 
     - name: Report coverage data
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         working-directory: ./python
         flags: unittests

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -207,7 +207,7 @@ class SocketServer(_BaseSocketServer):
         config = config.copy()
         if "address" in config:
             address = config.pop("address")
-            host, port = address.split(":", 1)
+            host, port = address.rsplit(":", 1)
             port = int(port)
         else:
             host = config.pop("host")
@@ -250,7 +250,7 @@ class SocketClient(Client):
     async def connect(
         dest_address: str, local_address: str | None = None, **kwargs
     ) -> "Client":
-        host, port_str = dest_address.split(":", 1)
+        host, port_str = dest_address.rsplit(":", 1)
         port = int(port_str)
         (reader, writer) = await asyncio.open_connection(host=host, port=port, **kwargs)
         channel = SocketChannel(

--- a/python/xoscar/backends/communication/ucx.py
+++ b/python/xoscar/backends/communication/ucx.py
@@ -401,7 +401,7 @@ class UCXServer(Server):
             prefix = f"{UCXServer.scheme}://"
             if address.startswith(prefix):
                 address = address[len(prefix) :]
-            host, port = address.split(":", 1)
+            host, port = address.rsplit(":", 1)
             port = int(port)
         else:
             host = config.pop("host")
@@ -498,7 +498,7 @@ class UCXClient(Client):
         prefix = f"{UCXClient.scheme}://"
         if dest_address.startswith(prefix):
             dest_address = dest_address[len(prefix) :]
-        host, port_str = dest_address.split(":", 1)
+        host, port_str = dest_address.rsplit(":", 1)
         port = int(port_str)
         kwargs = kwargs.copy()
         ucx_config = kwargs.pop("config", dict()).get("ucx", dict())

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -324,6 +324,7 @@ class MainActorPool(MainActorPoolBase):
         start_method: str | None = None,
         kwargs: dict | None = None,
     ):
+        # external_address has port 0, subprocess will bind random port.
         external_address = (
             external_address
             or MainActorPool.get_external_addresses(self.external_address, n_process=1)[
@@ -393,7 +394,7 @@ class MainActorPool(MainActorPoolBase):
             content=self._config,
         )
         await self.handle_control_command(control_message)
-
+        # The actual port will return in process_status.
         return process_status.external_addresses[0]
 
     async def remove_sub_pool(

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -132,7 +132,7 @@ class MainActorPool(MainActorPoolBase):
         """Get external address for every process"""
         assert n_process is not None
         if ":" in address:
-            host, port_str = address.split(":", 1)
+            host, port_str = address.rsplit(":", 1)
             port = int(port_str)
             if ports:
                 if len(ports) != n_process:

--- a/python/xoscar/backends/indigen/tests/test_pool.py
+++ b/python/xoscar/backends/indigen/tests/test_pool.py
@@ -30,7 +30,7 @@ import pytest
 from .... import Actor, create_actor, create_actor_ref, get_pool_config, kill_actor
 from ....context import get_context
 from ....errors import ActorNotExist, NoIdleSlot, SendMessageFailed, ServerClosed
-from ....tests.core import require_ucx
+from ....tests.core import require_ucx, require_unix
 from ....utils import get_next_port
 from ...allocate_strategy import (
     AddressSpecified,
@@ -543,6 +543,7 @@ async def test_create_actor_pool():
 
 
 @pytest.mark.asyncio
+@require_unix
 async def test_create_actor_pool_elastic_ip():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")
@@ -672,6 +673,7 @@ async def test_create_actor_pool_ipv6():
 
 
 @pytest.mark.asyncio
+@require_unix
 async def test_create_actor_pool_ipv6_elastic_ip():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")
@@ -1272,6 +1274,7 @@ async def test_append_sub_pool_multiprocess():
 
 
 @pytest.mark.asyncio
+@require_unix
 async def test_append_sub_pool_multi_process_elastic_ip():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")
@@ -1325,6 +1328,7 @@ async def test_append_sub_pool_multi_process_elastic_ip():
 
 
 @pytest.mark.asyncio
+@require_unix
 async def test_append_sub_pool_single_process_elastic_ip():
     start_method = (
         os.environ.get("POOL_START_METHOD", "forkserver")

--- a/python/xoscar/collective/core.py
+++ b/python/xoscar/collective/core.py
@@ -95,7 +95,7 @@ class RankActor(Actor):
         return self._backend
 
     def _get_ip(self) -> str:
-        return self.address.split(":")[0]
+        return self.address.rsplit(":", 1)[0]
 
     def _process_group_name(self, ranks: List[int]) -> str:
         return hashlib.sha1(

--- a/python/xoscar/tests/test_utils.py
+++ b/python/xoscar/tests/test_utils.py
@@ -164,20 +164,59 @@ def test_timer():
 
 def test_fix_all_zero_ip():
     assert utils.is_v4_zero_ip("0.0.0.0:1234") == True
+    assert utils.is_v4_zero_ip("ucx://0.0.0.0:1234") == True
     assert utils.is_v4_zero_ip("127.0.0.1:1234") == False
+    assert utils.is_v4_zero_ip("ucx://127.0.0.1:1234") == False
     assert utils.is_v6_zero_ip(":::1234") == True
+    assert utils.is_v6_zero_ip("ucx://:::1234") == True
     assert utils.is_v6_zero_ip("::FFFF:1234") == False
+    assert utils.is_v6_zero_ip("ucx://::FFFF:1234") == False
     return utils.is_v6_zero_ip("0000:0000:0000:0000:0000:0000:0000:0000:1234") == True
+    return (
+        utils.is_v6_zero_ip("ucx://0000:0000:0000:0000:0000:0000:0000:0000:1234")
+        == True
+    )
     return utils.is_v6_zero_ip("0:0:0:0:0:0:0:0:1234") == True
+    return utils.is_v6_zero_ip("ucx://0:0:0:0:0:0:0:0:1234") == True
     return utils.is_v6_zero_ip("0:0:0:0:0:1234") == True
+    return utils.is_v6_zero_ip("ucx://0:0:0:0:0:1234") == True
     assert utils.is_v6_zero_ip("2001:db8:3333:4444:5555:6666:7777:8888:1234") == False
+    assert (
+        utils.is_v6_zero_ip("ucx://2001:db8:3333:4444:5555:6666:7777:8888:1234")
+        == False
+    )
     assert utils.is_v6_zero_ip("127.0.0.1:1234") == False
+    assert utils.is_v6_zero_ip("ucx://127.0.0.1:1234") == False
+    # untouched
     assert utils.fix_all_zero_ip("127.0.0.1:1234", "127.0.0.1:5678") == "127.0.0.1:1234"
+    # untouched
+    assert (
+        utils.fix_all_zero_ip("ucx://127.0.0.1:1234", "ucx://127.0.0.1:5678")
+        == "ucx://127.0.0.1:1234"
+    )
+    # untouched
     assert utils.fix_all_zero_ip("0.0.0.0:1234", "0.0.0.0:5678") == "0.0.0.0:1234"
+    # untouched
+    assert (
+        utils.fix_all_zero_ip("ucx://0.0.0.0:1234", "ucx://0.0.0.0:5678")
+        == "ucx://0.0.0.0:1234"
+    )
+    # fixd with port change
     assert (
         utils.fix_all_zero_ip("0.0.0.0:1234", "192.168.0.1:5678") == "192.168.0.1:1234"
     )
+    # fixd with port change
+    assert (
+        utils.fix_all_zero_ip("ucx://0.0.0.0:1234", "ucx://192.168.0.1:5678")
+        == "ucx://192.168.0.1:1234"
+    )
+    # untouched
     assert utils.fix_all_zero_ip("127.0.0.1:1234", "0.0.0.0:5678") == "127.0.0.1:1234"
+    assert (
+        utils.fix_all_zero_ip("ucx://127.0.0.1:1234", "ucx://0.0.0.0:5678")
+        == "ucx://127.0.0.1:1234"
+    )
+    # fixed ipv6
     assert (
         utils.fix_all_zero_ip(":::1234", "2001:0db8:0001:0000:0000:0ab9:C0A8:0102:5678")
         == "2001:0db8:0001:0000:0000:0ab9:C0A8:0102:1234"

--- a/python/xoscar/utils.py
+++ b/python/xoscar/utils.py
@@ -480,6 +480,11 @@ def is_v6_zero_ip(ip_port_addr: str) -> bool:
     return True
 
 
+def is_v6_ip(ip_port_addr: str) -> bool:
+    arr = ip_port_addr.split("://", 1)[-1].split(":")
+    return len(arr) > 1
+
+
 def fix_all_zero_ip(remote_addr: str, connect_addr: str) -> str:
     """
     Use connect_addr to fix ActorRef.address return by remote server.

--- a/python/xoscar/utils.py
+++ b/python/xoscar/utils.py
@@ -465,12 +465,12 @@ def is_linux():
 
 
 def is_v4_zero_ip(ip_port_addr: str) -> bool:
-    return ip_port_addr.startswith("0.0.0.0:")
+    return ip_port_addr.split("://")[-1].startswith("0.0.0.0:")
 
 
 def is_v6_zero_ip(ip_port_addr: str) -> bool:
     # tcp6 addr ":::123", ":: means all zero"
-    arr = ip_port_addr.split(":")
+    arr = ip_port_addr.split("://")[-1].split(":")
     if len(arr) <= 2:  # Not tcp6 or udp6
         return False
     for part in arr[0:-1]:


### PR DESCRIPTION
create_actor_pool: Add extra_conf option listen_elastic_ip
    
Usage:
```
        create_actor_pool(elastic_address,
            n_process=0,
            extra_conf={'listen_elastic_ip': True},
        )
```
While xinference worker serve on cloud elastic_ip,
the address used in create_actor_pool() and create_actor both have to be the elastic ip,
in order for ActorRef passing around RPC method to client, but we could only listen on 0.0.0.0.
(Because the ip is not only valid outside the host)


Additional fixes:
1. The previous PR #92  does not consider ucx address format:  `ucx://127:0.0.1:3456`
2. Fix some address.split() for ipv6 case because ipv6 contains multiple `:` in the ip part

Add cross unittests for ipv6 X listen_elastic_ip X ucx.
The only missing part is ucx X ipv6, because ucx does not supoort ipv6 
ISSUE: https://github.com/xorbitsai/xoscar/issues/96

