### PR TITLE
BLD: Fix macos build

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,8 +13,8 @@ pull_request_rules:
       - check-success=build_test_job (ubuntu-latest, 3.9, xoscar)
       - check-success=build_test_job (ubuntu-latest, 3.10, xoscar)
       - check-success=build_test_job (ubuntu-latest, 3.11, xoscar)
-      - check-success=build_test_job (macos-latest, 3.8, xoscar)
-      - check-success=build_test_job (macos-latest, 3.11, xoscar)
+      - check-success=build_test_job (macos-13, 3.8, xoscar)
+      - check-success=build_test_job (macos-13, 3.11, xoscar)
       - check-success=build_test_job (windows-latest, 3.8, xoscar)
       - check-success=build_test_job (windows-latest, 3.11, xoscar)
       - check-success=codecov/project

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -36,14 +36,17 @@ jobs:
             arch: aarch64
             requires-python: ">=3.11,<3.12"
           - os: macos-latest
-            arch: arm64
-            requires-python: ">=3.9,<3.10"
+            arch: x86_64
+            requires-python: ">=3.8,<3.10"
           - os: macos-latest
-            arch: arm64
-            requires-python: ">=3.10,<3.11"
+            arch: x86_64
+            requires-python: ">=3.10,<3.12"
           - os: macos-latest
-            arch: arm64
-            requires-python: ">=3.11,<3.12"
+            arch: universal2
+            requires-python: ">=3.8,<3.10"
+          - os: macos-latest
+            arch: universal2
+            requires-python: ">=3.10,<3.12"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '55 14 * * *'
+    - cron: '30 4 * * *'
   push:
     tags:
       - '*'
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         arch: [auto]
         requires-python: [">=3.8,<3.10", ">=3.10,<3.12"]
         include:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '30 4 * * *'
+    - cron: '02 14 * * *'
   push:
     tags:
       - '*'

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -3,7 +3,7 @@ name: Build and upload to PyPI
 on:
   schedule:
     # trigger build every day at 4:30 UTC
-    - cron: '02 14 * * *'
+    - cron: '55 14 * * *'
   push:
     tags:
       - '*'
@@ -35,16 +35,16 @@ jobs:
           - os: ubuntu-latest
             arch: aarch64
             requires-python: ">=3.11,<3.12"
-          - os: macos-latest
+          - os: macos-12
             arch: x86_64
             requires-python: ">=3.8,<3.10"
-          - os: macos-latest
+          - os: macos-12
             arch: x86_64
             requires-python: ">=3.10,<3.12"
-          - os: macos-latest
+          - os: macos-12
             arch: universal2
             requires-python: ">=3.8,<3.10"
-          - os: macos-latest
+          - os: macos-12
             arch: universal2
             requires-python: ">=3.10,<3.12"
 

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -76,12 +76,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         module: ["xoscar"]
         exclude:
-          - { os: macos-latest, python-version: 3.9}
-          - { os: macos-latest, python-version: 3.10}
+          - { os: macos-13, python-version: 3.9}
+          - { os: macos-13, python-version: 3.10}
           - { os: windows-latest, python-version: 3.9}
           - { os: windows-latest, python-version: 3.10}
         include:


### PR DESCRIPTION
`macos-latest` runner updates Xcode: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
workaround: use `macos-13`.