### PR TITLE
ENH: Fix socket channel config bug

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -65,7 +65,6 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - '*'
-  # pull_request:
-  #   types: ['opened', 'reopened', 'synchronize']
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,7 +65,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xoscar'
+    if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - '*'
-  pull_request:
-    types: ['opened', 'reopened', 'synchronize']
+  # pull_request:
+  #   types: ['opened', 'reopened', 'synchronize']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,6 +65,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
+    # if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -204,9 +204,9 @@ class SocketServer(_BaseSocketServer):
     @classmethod
     def parse_config(cls, config: dict) -> dict:
         # we only need the following config
-        keys_of_interest = ['listen_elastic_ip', 'address', 'host', 'port']
+        keys_of_interest = ["listen_elastic_ip", "address", "host", "port"]
         parsed_config = {key: config[key] for key in keys_of_interest if key in config}
-    
+
         return parsed_config
 
     @staticmethod

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -201,10 +201,6 @@ class SocketServer(_BaseSocketServer):
     def channel_type(self) -> int:
         return ChannelType.remote
 
-    @classmethod
-    def parse_config(cls, config: dict) -> dict:
-        return config
-
     @staticmethod
     @implements(Server.create)
     async def create(config: Dict) -> "Server":

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -209,6 +209,8 @@ class SocketServer(_BaseSocketServer):
     @implements(Server.create)
     async def create(config: Dict) -> "Server":
         config = config.copy()
+        if "ucx" in config:
+            config.pop("ucx")
         if "address" in config:
             address = config.pop("address")
             host, port = address.rsplit(":", 1)

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -203,14 +203,16 @@ class SocketServer(_BaseSocketServer):
 
     @classmethod
     def parse_config(cls, config: dict) -> dict:
-        return config
+        # we only need the following config
+        keys_of_interest = ['listen_elastic_ip', 'address', 'host', 'port']
+        parsed_config = {key: config[key] for key in keys_of_interest if key in config}
+    
+        return parsed_config
 
     @staticmethod
     @implements(Server.create)
     async def create(config: Dict) -> "Server":
         config = config.copy()
-        if "ucx" in config:
-            config.pop("ucx")
         if "address" in config:
             address = config.pop("address")
             host, port = address.rsplit(":", 1)

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -203,9 +203,11 @@ class SocketServer(_BaseSocketServer):
 
     @classmethod
     def parse_config(cls, config: dict) -> dict:
+        if config is None or not config:
+            return dict()
         # we only need the following config
-        keys_of_interest = ["listen_elastic_ip", "address", "host", "port"]
-        parsed_config = {key: config[key] for key in keys_of_interest if key in config}
+        keys = ["listen_elastic_ip"]
+        parsed_config = {key: config[key] for key in keys if key in config}
 
         return parsed_config
 

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -201,6 +201,10 @@ class SocketServer(_BaseSocketServer):
     def channel_type(self) -> int:
         return ChannelType.remote
 
+    @classmethod
+    def parse_config(cls, config: dict) -> dict:
+        return config
+
     @staticmethod
     @implements(Server.create)
     async def create(config: Dict) -> "Server":


### PR DESCRIPTION
In the last [PR](https://github.com/xorbitsai/xoscar/pull/95), we added a `parse_config` method in socket channel. This method is mainly for extracting `listen_elastic_ip` in `extra_conf`. 
However, when xorbits calls it, this `config` contains keyword arguments like `ucx` in `extra_conf`.
The config will further affect the following code as `asyncio.start_server` does not have the `ucx` keyword argument.

```python
aio_server = await asyncio.start_server(
            handle_connection, host=_host, port=port, **config
        )
```

In xorbits, this config contains stuff about ucx like: `{'ucx': {'tcp': None, 'nvlink': None, 'infiniband': None, 'rdmacm': None, 'cuda-copy': None, 'create-cuda-contex': None}}`. This config is from `python/xorbits/_mars/deploy/oscar/base_config.yml`.

However, SocketChannel does not use the ucx config. So we do not need it here.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
