### PR TITLE
ENH: unpin "numpy<2.0" & move ucx-py to ucxx

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -106,9 +106,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: ${{ env.CONDA_ENV }}
 
-    # Fix "version `GLIBCXX_3.4.30' not found (required by xoscar_store.cpython-311-x86_64-linux-gnu.so)" issue in Python 3.11
+    # Fix "version `GLIBCXX_3.4.30' not found (required by xoscar_store.cpython-311-x86_64-linux-gnu.so)" issue
     - name: Install libstdcxx-ng for Python 3.11
-      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.11') }}
+      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') }}
       run: |
         conda install -c conda-forge libstdcxx-ng
 

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -65,7 +65,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xoscar'
+    if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -119,7 +119,6 @@ jobs:
       run: |
         pip install numpy scipy cython coverage flaky
         pip install -e ".[dev,extra]"
-        # ucx_info -v
       working-directory: ./python
 
     - name: Install ucx dependencies

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -125,6 +125,7 @@ jobs:
       if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.11') }}
       run: |
         conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
+        pip install -U numpy
 
     - name: Install fury
       if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9') }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -139,7 +139,7 @@ jobs:
         source activate ${{ env.CONDA_ENV }}
         conda install -y conda-forge::nccl=2.22.3
         pip install --extra-index-url=https://pypi.nvidia.com cudf-cu12
-        pip install ucx-py-cu12 cloudpickle psutil tblib uvloop packaging "numpy<2.0.0" scipy cython coverage flaky
+        pip install ucxx-cu12 cloudpickle psutil tblib uvloop packaging "numpy<2.0.0" scipy cython coverage flaky
         python setup.py clean --all
         pip install -e ./
       working-directory: ./python

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -107,7 +107,7 @@ jobs:
         activate-environment: ${{ env.CONDA_ENV }}
 
     # Fix "version `GLIBCXX_3.4.30' not found (required by xoscar_store.cpython-311-x86_64-linux-gnu.so)" issue
-    - name: Install libstdcxx-ng for Python 3.11
+    - name: Install libstdcxx-ng
       if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') }}
       run: |
         conda install -c conda-forge libstdcxx-ng
@@ -122,7 +122,7 @@ jobs:
       working-directory: ./python
 
     - name: Install ucx dependencies
-      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version >= '3.9')}}
+      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version >= '3.9')}}
       run: |
         # ucx-py move to ucxx and ucxx-cu12 can be run on CPU
         # conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -117,16 +117,16 @@ jobs:
         MODULE: ${{ matrix.module }}
       if: ${{ matrix.module != 'gpu' }}
       run: |
-        pip install numpy scipy cython coverage flaky ucxx-cu12
+        pip install numpy scipy cython coverage flaky
         pip install -e ".[dev,extra]"
-        ucx_info -v
+        # ucx_info -v
       working-directory: ./python
 
-    # - name: Install ucx dependencies
-    #   if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.11') }}
-    #   run: |
-    #     conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
-    #     pip install -U numpy
+    - name: Install ucx dependencies
+      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest')}}
+      run: |
+        # conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
+        pip install ucxx-cu12
 
     - name: Install fury
       if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9') }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -65,7 +65,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xoscar'
+    # if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -117,15 +117,16 @@ jobs:
         MODULE: ${{ matrix.module }}
       if: ${{ matrix.module != 'gpu' }}
       run: |
-        pip install numpy scipy cython coverage flaky
+        pip install numpy scipy cython coverage flaky ucxx-cu12
         pip install -e ".[dev,extra]"
+        ucx_info -v
       working-directory: ./python
 
-    - name: Install ucx dependencies
-      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.11') }}
-      run: |
-        conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
-        pip install -U numpy
+    # - name: Install ucx dependencies
+    #   if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.11') }}
+    #   run: |
+    #     conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
+    #     pip install -U numpy
 
     - name: Install fury
       if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9') }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -123,8 +123,9 @@ jobs:
       working-directory: ./python
 
     - name: Install ucx dependencies
-      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest')}}
+      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version >= '3.9')}}
       run: |
+        # ucx-py move to ucxx and ucxx-cu12 can be run on CPU
         # conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
         pip install ucxx-cu12
 

--- a/CI/conda-environment.yml
+++ b/CI/conda-environment.yml
@@ -2,7 +2,7 @@ name: xoscar-test
 channels:
   - defaults
 dependencies:
-  - numpy<2.0.0
+  - numpy
   - cloudpickle
   - coverage
   - cython

--- a/CI/requirements-wheel.txt
+++ b/CI/requirements-wheel.txt
@@ -1,6 +1,6 @@
 oldest-supported-numpy
 
-numpy<2.0.0
+numpy
 packaging
 wheel
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ requires = [
     "pandas==1.4.0; python_version>='3.10' and python_version<'3.11' and platform_machine=='arm64'",
     "pandas==1.5.1; python_version>='3.11' and python_version<'3.12'",
     "pandas>=2.1.1; python_version>'3.11'",
-    "numpy<2.0.0",
+    "numpy",
     "cython>=0.29.33",
     "requests>=2.4.0",
     "cloudpickle>=2.2.1; python_version>='3.11'",

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -24,7 +24,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    numpy>=1.14.0,<2.0.0
+    numpy>=1.14.0
     pandas>=1.0.0
     scipy>=1.0.0; sys_platform!="win32" or python_version>="3.10"
     scipy>=1.0.0,<=1.9.1; sys_platform=="win32" and python_version<"3.10"

--- a/python/xoscar/backends/communication/ucx.py
+++ b/python/xoscar/backends/communication/ucx.py
@@ -314,7 +314,7 @@ class UCXChannel(Channel):
                         await self.ucp_endpoint.send(buf)
                 for buffer in buffers:
                     await self.ucp_endpoint.send(buffer)
-        except ucp.exceptions.UCXError::  # pragma: no cover
+        except ucp.exceptions.UCXError:  # pragma: no cover
             self.abort()
             raise ChannelClosed("While writing, the connection was closed")
 

--- a/python/xoscar/serialization/core.pyx
+++ b/python/xoscar/serialization/core.pyx
@@ -55,7 +55,6 @@ from .pyfury import get_fury
 
 BUFFER_PICKLE_PROTOCOL = max(pickle.DEFAULT_PROTOCOL, 5)
 cdef bint HAS_PICKLE_BUFFER = pickle.HIGHEST_PROTOCOL >= 5
-cdef bint _PANDAS_HAS_MGR = hasattr(pd.Series([0]), "_mgr")
 
 cdef TypeDispatcher _serial_dispatcher = TypeDispatcher()
 cdef dict _deserializers = dict()
@@ -260,16 +259,7 @@ def unpickle_buffers(list buffers):
     else:
         result = cloudpickle.loads(buffers[0], buffers=buffers[1:])
 
-    # as pandas prior to 1.1.0 use _data instead of _mgr to hold BlockManager,
-    # deserializing from high versions may produce mal-functioned pandas objects,
-    # thus the patch is needed
-    if _PANDAS_HAS_MGR:
-        return result
-    else:  # pragma: no cover
-        if hasattr(result, "_mgr") and isinstance(result, (pd.DataFrame, pd.Series)):
-            result._data = getattr(result, "_mgr")
-            delattr(result, "_mgr")
-        return result
+    return result
 
 
 cdef class PickleSerializer(Serializer):


### PR DESCRIPTION
- unpin numpy < 2.0, remove old pandas code (< 1.1.0)
- move [ucx-py]() to [ucxx](https://github.com/rapidsai/ucxx/) as [ucxx](https://github.com/rapidsai/ucxx/) is the recommended package

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
