### PR TITLE
ENH: fix deprecation warning by pkgutil.find_loader

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -65,7 +65,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xoscar'
+    if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -65,7 +65,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xoscar'
+    # if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/python/xoscar/utils.py
+++ b/python/xoscar/utils.py
@@ -23,7 +23,6 @@ import inspect
 import io
 import logging
 import os
-import pkgutil
 import random
 import socket
 import sys

--- a/python/xoscar/utils.py
+++ b/python/xoscar/utils.py
@@ -19,6 +19,7 @@ import asyncio
 import dataclasses
 import functools
 import importlib
+import importlib.util as importlib_utils
 import inspect
 import io
 import logging
@@ -266,7 +267,7 @@ def lazy_import(
             self._on_loads.append(func)
             return func
 
-    if importlib.util.find_spec(prefix_name) is not None:
+    if importlib_utils.find_spec(prefix_name) is not None:
         return LazyModule()
     elif placeholder:
         return ModulePlaceholder(prefix_name)

--- a/python/xoscar/utils.py
+++ b/python/xoscar/utils.py
@@ -267,7 +267,7 @@ def lazy_import(
             self._on_loads.append(func)
             return func
 
-    if pkgutil.find_loader(prefix_name) is not None:
+    if importlib.util.find_spec(prefix_name) is not None:
         return LazyModule()
     elif placeholder:
         return ModulePlaceholder(prefix_name)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
fix deprecation warning by pkgutil.find_loader

DeprecationWarning: 'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec() instead

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->


## Check code requirements

- [ ] tests added / passed (if needed)
- [x] Ensure all linting tests pass
