### PR TITLE
FEAT: Add CONNECT_TIMEOUT option

### DIFF
--- a/python/xoscar/backends/indigen/tests/test_pool.py
+++ b/python/xoscar/backends/indigen/tests/test_pool.py
@@ -886,7 +886,7 @@ async def test_server_closed():
 
         # check if error raised normally when subprocess killed
         task = asyncio.create_task(actor_ref.sleep(10))
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
 
         # kill subprocess 1
         process = list(pool._sub_processes.values())[0]

--- a/python/xoscar/constants.py
+++ b/python/xoscar/constants.py
@@ -19,3 +19,5 @@ XOSCAR_TEMP_DIR = Path(os.getenv("XOSCAR_DIR", Path.home())) / ".xoscar"
 
 # unix socket.
 XOSCAR_UNIX_SOCKET_DIR = XOSCAR_TEMP_DIR / "socket"
+
+XOSCAR_CONNECT_TIMEOUT = 8


### PR DESCRIPTION
## What do these changes do?

asyncio default connection timeout is too long. we add CONNECT_TIMEOUT optional config default to 8 sec


## Related issue number

## Check code requirements

