### PR TITLE
BUG: Fix leaking clients in actor caller

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: psf/black@stable
         with:
           src: "python/xoscar"
-          options: "--check"
+          options: "--check --verbose"
       - uses: isort/isort-action@master
         with:
           sortPaths: "python/xoscar"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: psf/black@stable
         with:
           src: "python/xoscar"
-          options: "--check --verbose"
+          options: "--diff --verbose"
       - uses: isort/isort-action@master
         with:
           sortPaths: "python/xoscar"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: psf/black@stable
         with:
           src: "python/xoscar"
-          options: "--diff --verbose"
+          options: "--check"
       - uses: isort/isort-action@master
         with:
           sortPaths: "python/xoscar"

--- a/python/xoscar/backends/communication/dummy.py
+++ b/python/xoscar/backends/communication/dummy.py
@@ -100,9 +100,9 @@ class DummyServer(Server):
         else tuple()
     )
 
-    _address_to_instances: weakref.WeakValueDictionary[
-        str, "DummyServer"
-    ] = weakref.WeakValueDictionary()
+    _address_to_instances: weakref.WeakValueDictionary[str, "DummyServer"] = (
+        weakref.WeakValueDictionary()
+    )
     _channels: weakref.WeakSet[Channel]
     _tasks: set[asyncio.Task]
     scheme: str | None = "dummy"

--- a/python/xoscar/backends/communication/dummy.py
+++ b/python/xoscar/backends/communication/dummy.py
@@ -19,7 +19,7 @@ import asyncio
 import concurrent.futures as futures
 import logging
 import weakref
-from typing import Any, Callable, Coroutine, Dict, Type, Optional
+from typing import Any, Callable, Coroutine, Dict, Optional, Type
 from urllib.parse import urlparse
 
 from ...errors import ServerClosed

--- a/python/xoscar/backends/communication/dummy.py
+++ b/python/xoscar/backends/communication/dummy.py
@@ -19,7 +19,7 @@ import asyncio
 import concurrent.futures as futures
 import logging
 import weakref
-from typing import Any, Callable, Coroutine, Dict, Type
+from typing import Any, Callable, Coroutine, Dict, Type, Optional
 from urllib.parse import urlparse
 
 from ...errors import ServerClosed
@@ -206,7 +206,7 @@ class DummyClient(Client):
         self, local_address: str | None, dest_address: str | None, channel: Channel
     ):
         super().__init__(local_address, dest_address, channel)
-        self._task = None
+        self._task: Optional[asyncio.Task] = None
 
     @staticmethod
     @implements(Client.connect)

--- a/python/xoscar/backends/communication/dummy.py
+++ b/python/xoscar/backends/communication/dummy.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures as futures
+import logging
 import weakref
 from typing import Any, Callable, Coroutine, Dict, Type
 from urllib.parse import urlparse
@@ -29,13 +30,15 @@ from .errors import ChannelClosed
 
 DEFAULT_DUMMY_ADDRESS = "dummy://0"
 
+logger = logging.getLogger(__name__)
+
 
 class DummyChannel(Channel):
     """
     Channel for communications in same process.
     """
 
-    __slots__ = "_in_queue", "_out_queue", "_closed"
+    __slots__ = "__weakref__", "_in_queue", "_out_queue", "_closed"
 
     name = "dummy"
 
@@ -100,8 +103,8 @@ class DummyServer(Server):
     _address_to_instances: weakref.WeakValueDictionary[str, "DummyServer"] = (
         weakref.WeakValueDictionary()
     )
-    _channels: list[ChannelType]
-    _tasks: list[asyncio.Task]
+    _channels: weakref.WeakSet[Channel]
+    _tasks: set[asyncio.Task]
     scheme: str | None = "dummy"
 
     def __init__(
@@ -111,8 +114,8 @@ class DummyServer(Server):
     ):
         super().__init__(address, channel_handler)
         self._closed = asyncio.Event()
-        self._channels = []
-        self._tasks = []
+        self._channels = weakref.WeakSet()
+        self._tasks = set()
 
     @classmethod
     def get_instance(cls, address: str):
@@ -178,7 +181,7 @@ class DummyServer(Server):
                 f"{type(self).__name__} got unexpected "
                 f'arguments: {",".join(kwargs)}'
             )
-        self._channels.append(channel)
+        self._channels.add(channel)
         await self.channel_handler(channel)
 
     @implements(Server.stop)
@@ -203,6 +206,7 @@ class DummyClient(Client):
         self, local_address: str | None, dest_address: str | None, channel: Channel
     ):
         super().__init__(local_address, dest_address, channel)
+        self._task = None
 
     @staticmethod
     @implements(Client.connect)
@@ -232,11 +236,17 @@ class DummyClient(Client):
         task = asyncio.create_task(conn_coro)
         client = DummyClient(local_address, dest_address, client_channel)
         client._task = task
-        server._tasks.append(task)
+        server._tasks.add(task)
+        task.add_done_callback(server._tasks.discard)
         return client
 
     @implements(Client.close)
     async def close(self):
         await super().close()
-        self._task.cancel()
-        self._task = None
+        if self._task is not None:
+            task_loop = self._task.get_loop()
+            if task_loop is not None:
+                if not task_loop.is_running():
+                    logger.warning("Dummy channel cancel task on a stopped loop, dest address: %s.", self.dest_address)
+            self._task.cancel()
+            self._task = None

--- a/python/xoscar/backends/communication/dummy.py
+++ b/python/xoscar/backends/communication/dummy.py
@@ -100,9 +100,9 @@ class DummyServer(Server):
         else tuple()
     )
 
-    _address_to_instances: weakref.WeakValueDictionary[str, "DummyServer"] = (
-        weakref.WeakValueDictionary()
-    )
+    _address_to_instances: weakref.WeakValueDictionary[
+        str, "DummyServer"
+    ] = weakref.WeakValueDictionary()
     _channels: weakref.WeakSet[Channel]
     _tasks: set[asyncio.Task]
     scheme: str | None = "dummy"
@@ -247,6 +247,9 @@ class DummyClient(Client):
             task_loop = self._task.get_loop()
             if task_loop is not None:
                 if not task_loop.is_running():
-                    logger.warning("Dummy channel cancel task on a stopped loop, dest address: %s.", self.dest_address)
+                    logger.warning(
+                        "Dummy channel cancel task on a stopped loop, dest address: %s.",
+                        self.dest_address,
+                    )
             self._task.cancel()
             self._task = None

--- a/python/xoscar/backends/communication/dummy.py
+++ b/python/xoscar/backends/communication/dummy.py
@@ -237,7 +237,12 @@ class DummyClient(Client):
         client = DummyClient(local_address, dest_address, client_channel)
         client._task = task
         server._tasks.add(task)
-        task.add_done_callback(server._tasks.discard)
+
+        def _discard(t):
+            server._tasks.discard(t)
+            logger.info("Channel exit: %s", server_channel.info)
+
+        task.add_done_callback(_discard)
         return client
 
     @implements(Client.close)

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -179,6 +179,7 @@ class _BaseSocketServer(Server, metaclass=ABCMeta):
                 await channel.close()
             # Remove channel if channel exit
             self._channels.discard(channel)
+            logger.debug("Channel exit: %s", channel.info)
 
     @implements(Server.stop)
     async def stop(self):

--- a/python/xoscar/backends/communication/ucx.py
+++ b/python/xoscar/backends/communication/ucx.py
@@ -478,6 +478,7 @@ class UCXServer(Server):
                 await channel.close()
             # Remove channel if channel exit
             self._channels.discard(channel)
+            logger.debug("Channel exit: %s", channel.info)
 
     @implements(Server.stop)
     async def stop(self):

--- a/python/xoscar/backends/test/tests/test_actor_context.py
+++ b/python/xoscar/backends/test/tests/test_actor_context.py
@@ -12,13 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import asyncio
+import gc
 import os
 import sys
+import threading
 
 import pytest
 
 import xoscar as mo
+
+from ...communication.dummy import DummyServer
+from ...router import Router
 
 
 class DummyActor(mo.Actor):
@@ -60,3 +65,90 @@ async def test_simple(actor_pool_context):
         allocate_strategy=mo.allocate_strategy.RandomSubPool(),
     )
     assert await actor_ref.add(1) == 101
+
+
+def _cancel_all_tasks(loop):
+    to_cancel = asyncio.all_tasks(loop)
+    if not to_cancel:
+        return
+
+    for task in to_cancel:
+        task.cancel()
+
+    loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler(
+                {
+                    "message": "unhandled exception during asyncio.run() shutdown",
+                    "exception": task.exception(),
+                    "task": task,
+                }
+            )
+
+
+def _run_forever(loop):
+    loop.run_forever()
+    _cancel_all_tasks(loop)
+
+
+@pytest.mark.asyncio
+async def test_channel_cleanup(actor_pool_context):
+    pool = actor_pool_context
+    actor_ref = await mo.create_actor(
+        DummyActor,
+        0,
+        address=pool.external_address,
+        allocate_strategy=mo.allocate_strategy.RandomSubPool(),
+    )
+
+    curr_router = Router.get_instance()
+    server_address = curr_router.get_internal_address(actor_ref.address)
+    dummy_server = DummyServer.get_instance(server_address)
+
+    async def inc():
+        await asyncio.gather(*(actor_ref.add.tell(1) for _ in range(10)))
+
+    loops = []
+    threads = []
+    futures = []
+    for _ in range(10):
+        loop = asyncio.new_event_loop()
+        t = threading.Thread(target=_run_forever, args=(loop,))
+        t.start()
+        loops.append(loop)
+        threads.append(t)
+        fut = asyncio.run_coroutine_threadsafe(inc(), loop=loop)
+        futures.append(fut)
+
+    for fut in futures:
+        fut.result()
+
+    while True:
+        if await actor_ref.add(0) == 100:
+            break
+
+    assert len(dummy_server._channels) == 12
+    assert len(dummy_server._tasks) == 12
+
+    for loop in loops:
+        loop.call_soon_threadsafe(loop.stop)
+
+    for t in threads:
+        t.join()
+    threads.clear()
+
+    curr_router = Router.get_instance()
+    server_address = curr_router.get_internal_address(actor_ref.address)
+    dummy_server = DummyServer.get_instance(server_address)
+
+    while True:
+        gc.collect()
+        # Two channels left:
+        #   1. from the main pool to the actor
+        #   2. from current main thread to the actor.
+        if len(dummy_server._channels) == 2 and len(dummy_server._tasks) == 2:
+            break


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

Background: If an actor is called from a thread and the thread exits after the call, the client will leak in the actor caller, and the corresponding channel will still be open.

This PR auto close the actor callers and channels that belongs to the exited thread.

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
