### PR TITLE
BUG: Fix ValueError when creating actor with class object as first argument

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -135,11 +135,6 @@ jobs:
         # conda install -c conda-forge -c rapidsai ucx-proc=*=cpu ucx ucx-py
         pip install ucxx-cu12
 
-    - name: Install fury
-      if: ${{ (matrix.module != 'gpu') && (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9') }}
-      run: |
-        pip install pyfury
-
     - name: Install on GPU
       if: ${{ matrix.module == 'gpu' }}
       run: |

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -66,7 +66,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    if: github.repository == 'xorbitsai/xoscar'
+    # if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -66,7 +66,7 @@ jobs:
           find . -name "CMakeLists.txt" -not -path "*third_party/*" | xargs cmake-format -c .cmake-format.yaml --check
 
   build_test_job:
-    # if: github.repository == 'xorbitsai/xoscar'
+    if: github.repository == 'xorbitsai/xoscar'
     runs-on: ${{ matrix.os }}
     needs: lint
     env:

--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -213,7 +213,7 @@ def create_actor_ref(*args, **kwargs):
     if kwargs:
         raise ValueError('Only `address` or `uid` keywords are supported')
 
-    # args: address, uid, proxy_addresses
+    # args: [address, uid], or [address, uid, proxy_addresses]
     if 2 <= len(args) <= 3 and isinstance(args[0], (str, bytes)):
         if address:
             raise ValueError('address has been specified')

--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -213,7 +213,8 @@ def create_actor_ref(*args, **kwargs):
     if kwargs:
         raise ValueError('Only `address` or `uid` keywords are supported')
 
-    if 2 <= len(args) <= 3:
+    # args: address, uid, proxy_addresses
+    if 2 <= len(args) <= 3 and isinstance(args[0], (str, bytes)):
         if address:
             raise ValueError('address has been specified')
         address = to_str(args[0])

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -58,19 +58,13 @@ class UVVirtualEnvManager(VirtualEnvManager):
         if "trusted_host" in kwargs and kwargs["trusted_host"]:
             cmd += ["--trusted-host", kwargs["trusted_host"]]
 
-        self._install_process = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        stdout, stderr = self._install_process.communicate()
-        returncode = self._install_process.returncode
+        self._install_process = process = subprocess.Popen(cmd)
+        returncode = process.wait()
 
         self._install_process = None  # install finished, clear reference
 
         if returncode != 0:
-            raise subprocess.CalledProcessError(
-                returncode, cmd, output=stdout, stderr=stderr
-            )
+            raise subprocess.CalledProcessError(returncode, cmd)
 
     def cancel_install(self):
         if self._install_process and self._install_process.poll() is None:


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

The https://github.com/xorbitsai/xoscar/pull/126 introduced a `proxy_address` variable in `create_actor_ref(args)`, while `create_actor_ref(args)` can accept different kinds of `args`.

This PR fixes an issue in the `create_actor_ref` function where a ValueError was raised when trying to create an actor with a class object as the first argument, i.e., `create_actor_ref(ActorCls, other_args, other_kw_args)`.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
