### PR TITLE
ENH: get_python_path() returns value when path exists

### DIFF
--- a/python/xoscar/utils.py
+++ b/python/xoscar/utils.py
@@ -89,7 +89,7 @@ def wrap_exception(
 ) -> BaseException:
     """Generate an exception wraps the cause exception."""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         pass
 
     def __getattr__(self, item):

--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -40,7 +40,7 @@ class VirtualEnvManager(ABC):
         pass
 
     @abstractmethod
-    def get_python_path(self) -> str:
+    def get_python_path(self) -> str | None:
         pass
 
     @abstractmethod


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR fixed `get_python_path`, only returns value when path exists.

And shown in https://github.com/xorbitsai/inference/issues/3390 , no clue when the wrapped exception will be inited, thus added *args and **kwargs to prevent from hiding real error.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
