### PR TITLE
FEAT: extended packages for virtualenv

### DIFF
--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import importlib
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -34,6 +35,43 @@ class VirtualEnvManager(ABC):
     @abstractmethod
     def install_packages(self, packages: list[str], **kwargs):
         pass
+
+    @staticmethod
+    def process_packages(packages: list[str]) -> list[str]:
+        """
+        Process a list of package names, replacing placeholders like #system_<package>#
+        with the installed version of the corresponding package from the system environment.
+
+        Example:
+            "#system_torch#" -> "torch==2.1.0" (if torch 2.1.0 is installed)
+
+        Args:
+            packages (list[str]): A list of package names, which may include placeholders.
+
+        Returns:
+            list[str]: A new list with resolved package names and versions.
+
+        Raises:
+            RuntimeError: If a specified system package is not found in the environment.
+        """
+        processed = []
+
+        for pkg in packages:
+            if pkg.startswith("#system_") and pkg.endswith("#"):
+                real_pkg = pkg[
+                    len("#system_") : -1
+                ]  # Extract actual package name, e.g., "torch"
+                try:
+                    version = importlib.metadata.version(real_pkg)
+                except importlib.metadata.PackageNotFoundError:
+                    raise RuntimeError(
+                        f"System package '{real_pkg}' not found. Cannot resolve '{pkg}'."
+                    )
+                processed.append(f"{real_pkg}=={version}")
+            else:
+                processed.append(pkg)
+
+        return processed
 
     @abstractmethod
     def cancel_install(self):

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -46,6 +46,10 @@ class UVVirtualEnvManager(VirtualEnvManager):
         if not packages:
             return
 
+        # extend the ability of pip
+        # maybe replace #system_torch# to the real version
+        packages = self.process_packages(packages)
+
         cmd = ["uv", "pip", "install", "-p", str(self.env_path)] + packages
 
         # Handle known pip-related kwargs


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

For the virtualenv, if the system site packages has some lib, for instance torch==2.6, if the packages to install rely on torch, the uv will try to install torch no matter it's installed in system site packages or not, thus maybe torch==2.7 will be installed, this will cause many issues, e.g. torchvision in system site packages may be incompatible. Hence, this PR add some special syntax for packages, e.g. `#system_torch#` , and it will be replaced with real version installed in system site pacakges.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
