### PR TITLE
ENH: specifying env when creating sub pool (before updating os.environ when sub pool created)

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -160,10 +160,10 @@ jobs:
         if [[ "$MODULE" == "xoscar" ]]; then
           pytest -s -v --timeout=500 \
             -W ignore::PendingDeprecationWarning \
-            --cov-config=setup.cfg --cov-report=xml --cov=xoscar xoscar --capture=no
+            --cov-config=setup.cfg --cov-report=xml --cov=xoscar xoscar
         else
           source activate ${{ env.CONDA_ENV }}
-          pytest -v -m cuda --cov-config=setup.cfg --cov-report=xml --cov=xoscar --capture=no
+          pytest -s -v -m cuda --cov-config=setup.cfg --cov-report=xml --cov=xoscar
         fi
       working-directory: ./python
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,10 @@ asyncio_default_fixture_loop_scope="function"
 markers = [
     "cuda: mark a test as a cuda case.",
 ]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.cibuildwheel]
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -287,7 +287,7 @@ class MainActorPool(MainActorPoolBase):
                 "-sn",
                 shm.name,
             ]
-            parent_env = dict(os.getenv())
+            parent_env = dict(os.environ)
             env = actor_pool_config.get_pool_config(process_index).get("env") or {}
             parent_env.update(env)
             logger.info(

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -287,13 +287,15 @@ class MainActorPool(MainActorPoolBase):
                 "-sn",
                 shm.name,
             ]
-            parent_env = dict(os.environ)
+            new_env = dict(os.environ)
             env = actor_pool_config.get_pool_config(process_index).get("env") or {}
-            parent_env.update(env)
+            new_env.update(env)
             logger.info(
-                "Creating sub pool via command: %s, env: %s", cmd, pprint.pformat(env)
+                "Creating sub pool via command: %s, env: %s",
+                cmd,
+                pprint.pformat(new_env),
             )
-            process = await create_subprocess_exec(*cmd, env=env)
+            process = await create_subprocess_exec(*cmd, env=new_env)
 
             def _get_external_addresses():
                 try:

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -22,6 +22,7 @@ import itertools
 import logging.config
 import os
 import pickle
+import pprint
 import random
 import signal
 import struct
@@ -286,8 +287,12 @@ class MainActorPool(MainActorPoolBase):
                 "-sn",
                 shm.name,
             ]
-            env = actor_pool_config.get_pool_config(process_index).get("env")
-            logger.info("Creating sub pool via command: %s, env: %s", cmd, env)
+            parent_env = dict(os.getenv())
+            env = actor_pool_config.get_pool_config(process_index).get("env") or {}
+            parent_env.update(env)
+            logger.info(
+                "Creating sub pool via command: %s, env: %s", cmd, pprint.pformat(env)
+            )
             process = await create_subprocess_exec(*cmd, env=env)
 
             def _get_external_addresses():

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -187,7 +187,7 @@ class MainActorPool(MainActorPoolBase):
                         psutil.Process(main_pool_pid)
                     except psutil.NoSuchProcess:
                         logger.error("Exit due to main pool %s exit.", main_pool_pid)
-                        os._exit(233)  # Special exit code for debug.
+                        os._exit(233)  # Special exit code for debugging.
                     except Exception as e:
                         logger.exception("Check ppid failed: %s", e)
                     time.sleep(10)
@@ -286,6 +286,7 @@ class MainActorPool(MainActorPoolBase):
                 "-sn",
                 shm.name,
             ]
+            # We need to inherit the parent environment to ensure the subprocess works correctly on Windows.
             new_env = dict(os.environ)
             env = actor_pool_config.get_pool_config(process_index).get("env") or {}
             new_env.update(env)

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -286,8 +286,9 @@ class MainActorPool(MainActorPoolBase):
                 "-sn",
                 shm.name,
             ]
-            logger.info("Creating sub pool via command: %s", cmd)
-            process = await create_subprocess_exec(*cmd)
+            env = actor_pool_config.get_pool_config(process_index).get("env")
+            logger.info("Creating sub pool via command: %s, env: %s", cmd, env)
+            process = await create_subprocess_exec(*cmd, env=env)
 
             def _get_external_addresses():
                 try:

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -22,7 +22,6 @@ import itertools
 import logging.config
 import os
 import pickle
-import pprint
 import random
 import signal
 import struct
@@ -290,11 +289,7 @@ class MainActorPool(MainActorPoolBase):
             new_env = dict(os.environ)
             env = actor_pool_config.get_pool_config(process_index).get("env") or {}
             new_env.update(env)
-            logger.info(
-                "Creating sub pool via command: %s, env: %s",
-                cmd,
-                pprint.pformat(new_env),
-            )
+            logger.info("Creating sub pool via command: %s", cmd)
             process = await create_subprocess_exec(*cmd, env=new_env)
 
             def _get_external_addresses():

--- a/python/xoscar/backends/indigen/pool.py
+++ b/python/xoscar/backends/indigen/pool.py
@@ -186,8 +186,8 @@ class MainActorPool(MainActorPoolBase):
                         # as the double fork may result in a new process as the parent.
                         psutil.Process(main_pool_pid)
                     except psutil.NoSuchProcess:
-                        logger.info("Exit due to main pool %s exit.", main_pool_pid)
-                        os._exit(0)
+                        logger.error("Exit due to main pool %s exit.", main_pool_pid)
+                        os._exit(233)  # Special exit code for debug.
                     except Exception as e:
                         logger.exception("Check ppid failed: %s", e)
                     time.sleep(10)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
