### PR TITLE
ENH: support exists_env and create_env(exists="error|ignore|clear")

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -89,7 +89,6 @@ jobs:
           - { os: windows-latest, python-version: 3.11}
         include:
           - { os: self-hosted, module: gpu, python-version: 3.11}
-          - { os: ubuntu-20.04, module: doc-build, python-version: 3.9}
 
     steps:
     - name: Check out code
@@ -146,14 +145,7 @@ jobs:
         pip install -e ./
       working-directory: ./python
 
-    - name: Build doc
-      if: ${{ matrix.module == 'doc-build' }}
-      run: |
-        make html
-      working-directory: ./doc
-
     - name: Test with pytest
-      if: ${{ matrix.module != 'doc-build'}}
       env:
         MODULE: ${{ matrix.module }}
       run: |

--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -29,7 +29,13 @@ class VirtualEnvManager(ABC):
         self.env_path = env_path.resolve()
 
     @abstractmethod
-    def create_env(self, python_path: Path | None = None) -> None:
+    def exists_env(self) -> bool:
+        pass
+
+    @abstractmethod
+    def create_env(
+        self, python_path: Path | None = None, exists: str = "ignore"
+    ) -> None:
         pass
 
     @abstractmethod


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

SInce latest uv would ask clear or not for an env, and in XInference we basically just call `create_env` without checking in advance, thus we added option, by default ignore to make it compatible with old behavior.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
