### PR TITLE
ENH: support extended requirements syntax for virtualenv packages

### DIFF
--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -30,6 +30,7 @@ from .platform import (
     get_cuda_arch,
     get_cuda_version,
 )
+from .utils import is_vcs_url
 
 
 class VirtualEnvManager(ABC):
@@ -243,7 +244,9 @@ def filter_requirements(requirements: list[str]) -> list[str]:
     env = get_env()
     result = []
     for req_str in requirements:
-        if ";" in req_str:
+        if is_vcs_url(req_str):
+            result.append(req_str)
+        elif ";" in req_str:
             req_part, marker_part = req_str.split(";", 1)
             marker_part = marker_part.strip()
             try:

--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -259,9 +259,7 @@ def filter_requirements(requirements: list[str]) -> list[str]:
                 else:
                     raise
         else:
-            try:
-                req = Requirement(req_str.strip())
-                result.append(str(req))
-            except InvalidRequirement:
-                pass
+            req = Requirement(req_str.strip())
+            result.append(str(req))
+
     return result

--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -14,9 +14,22 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
+import operator
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+from packaging.markers import Marker, default_environment
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import Version
+
+from .platform import (
+    check_cuda_available,
+    check_npu_available,
+    get_cuda_arch,
+    get_cuda_version,
+)
 
 
 class VirtualEnvManager(ABC):
@@ -79,6 +92,13 @@ class VirtualEnvManager(ABC):
             else:
                 processed.append(pkg)
 
+        # apply extended syntax including:
+        # - has_cuda: whether CUDA is available (bool)
+        # - cuda_version: CUDA version string, e.g. "12.1" (str)
+        # - cuda_arch: CUDA architecture string, e.g. "sm_80" (str)
+        # - has_npu: whether an NPU is available (bool)
+        processed = filter_requirements(processed)
+
         return processed
 
     @abstractmethod
@@ -96,3 +116,152 @@ class VirtualEnvManager(ABC):
     @abstractmethod
     def remove_env(self):
         pass
+
+
+def get_env() -> dict[str, str | bool]:
+    env = default_environment().copy()
+    # Your custom env vars here, e.g.:
+    env.update(
+        {
+            "has_cuda": check_cuda_available(),
+            "cuda_version": get_cuda_version(),
+            "cuda_arch": get_cuda_arch(),
+            "has_npu": check_npu_available(),
+        }
+    )
+    return env
+
+
+STANDARD_ENV_VARS = set(default_environment().keys())
+
+
+def is_custom_marker(marker_str: str) -> bool:
+    try:
+        marker = Marker(marker_str)
+    except Exception:
+        return True
+
+    def traverse_markers(node):
+        if isinstance(node, tuple):
+            env_var = node[0]
+            if env_var not in STANDARD_ENV_VARS:
+                return True
+            return False
+        elif isinstance(node, list):
+            return any(traverse_markers(child) for child in node)
+        return False
+
+    return traverse_markers(marker._markers)
+
+
+def eval_custom_marker(marker_str: str, env: dict) -> bool:
+    ops = {
+        ast.Eq: operator.eq,
+        ast.NotEq: operator.ne,
+        ast.Lt: operator.lt,
+        ast.LtE: operator.le,
+        ast.Gt: operator.gt,
+        ast.GtE: operator.ge,
+        ast.And: lambda a, b: a and b,
+        ast.Or: lambda a, b: a or b,
+        ast.Not: operator.not_,
+    }
+
+    def normalize_value(val):
+        # Normalize for boolean
+        if isinstance(val, str):
+            if val.lower() == "true":
+                return True
+            if val.lower() == "false":
+                return False
+
+        # Normalize for version-like fields
+        if isinstance(val, str):
+            if val.count(".") >= 1 and all(
+                part.isdigit() for part in val.split(".") if part
+            ):
+                return Version(val)
+
+        return val
+
+    def maybe_parse_cuda_arch(val):
+        if isinstance(val, str) and val.startswith("sm_"):
+            try:
+                return int(val[3:])
+            except ValueError:
+                return val
+        return val
+
+    def _eval(node):
+        if isinstance(node, ast.BoolOp):
+            left = _eval(node.values[0])
+            for right_node in node.values[1:]:
+                right = _eval(right_node)
+                op = ops[type(node.op)]
+                left = op(left, right)
+            return left
+
+        elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            return not _eval(node.operand)
+
+        elif isinstance(node, ast.Compare):
+            left = _eval(node.left)
+            left = maybe_parse_cuda_arch(normalize_value(left))
+
+            for op_node, right_expr in zip(node.ops, node.comparators):
+                right = _eval(right_expr)
+                right = maybe_parse_cuda_arch(normalize_value(right))
+
+                op_func = ops[type(op_node)]
+                if not op_func(left, right):
+                    return False
+                left = right  # for chained comparisons
+
+            return True
+
+        elif isinstance(node, ast.Name):
+            return normalize_value(env.get(node.id))
+
+        elif isinstance(node, ast.Constant):
+            return node.value
+
+        elif isinstance(node, ast.Str):  # Python <3.8
+            return node.s
+
+        else:
+            raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    tree = ast.parse(marker_str, mode="eval")
+    return _eval(tree.body)
+
+
+def filter_requirements(requirements: list[str]) -> list[str]:
+    """
+    Filter requirements by evaluating markers in given env.
+    If env is None, use get_env().
+    """
+    env = get_env()
+    result = []
+    for req_str in requirements:
+        if ";" in req_str:
+            req_part, marker_part = req_str.split(";", 1)
+            marker_part = marker_part.strip()
+            try:
+                req = Requirement(req_str)
+                if req.marker is None or req.marker.evaluate(env):
+                    result.append(f"{req.name}{req.specifier}")
+                    continue
+            except InvalidRequirement:
+                if is_custom_marker(marker_part):
+                    if eval_custom_marker(marker_part, env):
+                        req = Requirement(req_part.strip())
+                        result.append(str(req))
+                else:
+                    raise
+        else:
+            try:
+                req = Requirement(req_str.strip())
+                result.append(str(req))
+            except InvalidRequirement:
+                pass
+    return result

--- a/python/xoscar/virtualenv/platform.py
+++ b/python/xoscar/virtualenv/platform.py
@@ -1,0 +1,53 @@
+# Copyright 2022-2025 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+
+def check_cuda_available() -> bool:
+    try:
+        import torch
+
+        return torch.cuda.is_available()
+    except (ImportError, AttributeError):
+        return False
+
+
+def get_cuda_version() -> Optional[str]:
+    try:
+        import torch
+
+        return torch.version.cuda  # e.g. '12.1'
+    except (ImportError, AttributeError):
+        return None
+
+
+def get_cuda_arch() -> Optional[str]:
+    try:
+        import torch
+
+        major, minor = torch.cuda.get_device_capability()
+        return f"sm_{major}{minor}"  # e.g. 'sm_80'
+    except (ImportError, AttributeError):
+        return None
+
+
+def check_npu_available() -> bool:
+    try:
+        import torch
+        import torch_npu  # noqa: F401
+
+        return torch.npu.is_available()
+    except ImportError:
+        return False

--- a/python/xoscar/virtualenv/tests/test_core.py
+++ b/python/xoscar/virtualenv/tests/test_core.py
@@ -16,8 +16,9 @@ from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 import pytest
+from packaging.markers import default_environment
 
-from ..core import VirtualEnvManager
+from ..core import VirtualEnvManager, filter_requirements
 
 
 def test_system_package_with_plus_cpu():
@@ -42,3 +43,91 @@ def test_package_not_found():
     with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
         with pytest.raises(RuntimeError, match="System package 'notexist' not found"):
             VirtualEnvManager.process_packages(["#system_notexist#"])
+
+
+@pytest.mark.parametrize(
+    "input_env, input_pkgs, expected_pkgs",
+    [
+        # Only built-in env vars (standard markers)
+        (
+            {"sys_platform": "linux", "python_version": "3.8"},
+            ["foo ; sys_platform == 'linux'", "bar ; sys_platform == 'win32'"],
+            ["foo"],
+        ),
+        # Only custom env vars, boolean check true
+        (
+            {"has_cuda": True},
+            ["torch ; has_cuda", "cpu-lib ; not has_cuda"],
+            ["torch"],
+        ),
+        # Only custom env vars, boolean check false
+        (
+            {"has_cuda": False},
+            ["torch ; has_cuda", "cpu-lib ; not has_cuda"],
+            ["cpu-lib"],
+        ),
+        # Mixed built-in and custom env vars, with comparison value
+        (
+            {"has_cuda": True, "sys_platform": "linux"},
+            [
+                "torch==2.0 ; has_cuda and sys_platform == 'linux'",
+                "xformers ; sys_platform == 'win32' or not has_cuda",
+            ],
+            ["torch==2.0"],
+        ),
+        # Mixed with custom boolean false
+        (
+            {"has_cuda": False, "sys_platform": "win32"},
+            [
+                "torch==2.0 ; has_cuda and sys_platform == 'linux'",
+                "xformers ; sys_platform == 'win32' or not has_cuda",
+            ],
+            ["xformers"],
+        ),
+        # Custom marker with simple comparison (custom marker with value)
+        (
+            {"cuda_version": "12.1"},
+            ["torch ; cuda_version >= '12.0'", "torch_old ; cuda_version < '12.0'"],
+            ["torch"],
+        ),
+        # Custom marker boolean AND with built-in OR
+        (
+            {"has_cuda": True, "sys_platform": "darwin"},
+            [
+                "torch ; has_cuda and (sys_platform == 'linux' or sys_platform == 'darwin')",
+                "xformers ; sys_platform == 'win32' or not has_cuda",
+            ],
+            ["torch"],
+        ),
+        # Custom cuda_arch numeric comparison
+        (
+            {"cuda_arch": "sm_120"},
+            ["fast-lib ; cuda_arch >= 'sm_80'", "old-lib ; cuda_arch < 'sm_80'"],
+            ["fast-lib"],
+        ),
+        # Boolean false with negation and OR
+        (
+            {"has_cuda": False, "sys_platform": "linux"},
+            [
+                "lib1 ; not has_cuda and sys_platform == 'linux'",
+                "lib2 ; has_cuda or sys_platform == 'win32'",
+            ],
+            ["lib1"],
+        ),
+    ],
+)
+def test_filter_requirements_with_combined_markers(
+    input_env, input_pkgs, expected_pkgs
+):
+    # Convert all env values to string for marker.evaluate
+    std_env = default_environment()
+    std_env.update(
+        {
+            k: str(v).lower() if isinstance(v, bool) else str(v)
+            for k, v in input_env.items()
+        }
+    )
+
+    with patch("xoscar.virtualenv.core.get_env", return_value=std_env):
+        filtered = filter_requirements(input_pkgs)
+        assert set(filtered) == set(expected_pkgs)

--- a/python/xoscar/virtualenv/utils.py
+++ b/python/xoscar/virtualenv/utils.py
@@ -82,3 +82,19 @@ def run_subprocess_with_logger(
         process.wait()
         for t in threads:
             t.join()
+
+
+def is_vcs_url(spec_str: str) -> bool:
+    """
+    Check if the given spec string is a VCS URL.
+
+    Supports common VCS schemes like git+, svn+, hg+, bzr+, and HTTP/HTTPS URLs.
+
+    Args:
+        spec_str (str): The package spec string.
+
+    Returns:
+        bool: True if it's a VCS URL, False otherwise.
+    """
+    vcs_prefixes = ("git+", "http://", "https://", "svn+", "hg+", "bzr+")
+    return spec_str.startswith(vcs_prefixes)

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -30,7 +30,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from .core import VirtualEnvManager
-from .utils import run_subprocess_with_logger
+from .utils import is_vcs_url, run_subprocess_with_logger
 
 UV_PATH = os.getenv("XOSCAR_UV_PATH")
 SKIP_INSTALLED = bool(int(os.getenv("XOSCAR_VIRTUAL_ENV_SKIP_INSTALLED", "0")))
@@ -163,9 +163,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
 
         for spec_str in specs:
             # skip git+xxx
-            if spec_str.startswith(
-                ("git+", "http://", "https://", "svn+", "hg+", "bzr+")
-            ):
+            if is_vcs_url(spec_str):
                 keep.append(spec_str)
                 continue
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Extended syntax includes:

```
torch==2.0 ; has_cuda
xformers ; cuda_version >= '12.0'
cpu-lib ; not has_cuda
npu-lib ; has_npu
gpu-toolkit ; cuda_arch >= 'sm_80'
special-driver ; has_cuda and sys_platform == 'linux'
win-tool ; has_cuda and sys_platform == 'win32'
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
