### PR TITLE
BUG: Ignore virtual environment installation when the filtered package list is empty.

### DIFF
--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -239,6 +239,9 @@ class UVVirtualEnvManager(VirtualEnvManager):
             return
 
         packages = self.process_packages(packages)
+		if not packages:
+            return
+
         log = kwargs.pop("log", False)
         skip_installed = kwargs.pop("skip_installed", SKIP_INSTALLED)
         uv_path = self._get_uv_path()

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -239,7 +239,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
             return
 
         packages = self.process_packages(packages)
-		if not packages:
+        if not packages:
             return
 
         log = kwargs.pop("log", False)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
当虚拟环境的包过滤后为空的时候会报错，修复该错误

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
