### PR TITLE
BUG: fix AssertionError in virtualenv when no cuda available

### DIFF
--- a/python/xoscar/virtualenv/platform.py
+++ b/python/xoscar/virtualenv/platform.py
@@ -39,7 +39,10 @@ def get_cuda_arch() -> Optional[str]:
 
         major, minor = torch.cuda.get_device_capability()
         return f"sm_{major}{minor}"  # e.g. 'sm_80'
-    except (ImportError, AttributeError):
+    except (ImportError, AttributeError, AssertionError):
+        # If no cuda available,
+        # AssertionError("Torch not compiled with CUDA enabled")
+        # will be raised
         return None
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

When no cuda, virtualenv detection may fail:

```
2025-09-22 06:59:58,577 xinference.core.worker 1 INFO     Installing packages ['datasets==3.2.0', '#system_numpy#', '#system_torch#'] in virtual env /data/virtualenv/v2/camp, with settings(index_url=https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple)
2025-09-22 06:59:58,582 xinference.core.worker 1 ERROR    Failed to load model camp-0
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/site-packages/xinference/core/worker.py", line 1089, in launch_builtin_model
    await asyncio.to_thread(
  File "/opt/conda/lib/python3.11/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xinference/core/worker.py", line 869, in _prepare_virtual_env
    virtual_env_manager.install_packages(packages, **conf)
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/uv.py", line 241, in install_packages
    packages = self.process_packages(packages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/core.py", line 101, in process_packages
    processed = filter_requirements(processed)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/core.py", line 244, in filter_requirements
    env = get_env()
          ^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/core.py", line 129, in get_env
    "cuda_arch": get_cuda_arch(),
                 ^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/platform.py", line 40, in get_cuda_arch
    major, minor = torch.cuda.get_device_capability()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/cuda/__init__.py", line 600, in get_device_capability
    prop = get_device_properties(device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/cuda/__init__.py", line 616, in get_device_properties
    _lazy_init()  # will define _get_device_properties
    ^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/cuda/__init__.py", line 403, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
2025-09-22 06:59:58,592 xinference.core.worker 1 ERROR    [request c0236b3c-9781-11f0-9acf-4ccc6a0d93e0] Leave launch_builtin_model, error: Torch not compiled with CUDA enabled, elapsed time: 0 s
Traceback (most recent call last):
  File "/opt/conda/lib/python3.11/site-packages/xinference/core/utils.py", line 93, in wrapped
    ret = await func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xinference/core/worker.py", line 1089, in launch_builtin_model
    await asyncio.to_thread(
  File "/opt/conda/lib/python3.11/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xinference/core/worker.py", line 869, in _prepare_virtual_env
    virtual_env_manager.install_packages(packages, **conf)
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/uv.py", line 241, in install_packages
    packages = self.process_packages(packages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/core.py", line 101, in process_packages
    processed = filter_requirements(processed)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/core.py", line 244, in filter_requirements
    env = get_env()
          ^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/core.py", line 129, in get_env
    "cuda_arch": get_cuda_arch(),
                 ^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/xoscar/virtualenv/platform.py", line 40, in get_cuda_arch
    major, minor = torch.cuda.get_device_capability()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/cuda/__init__.py", line 600, in get_device_capability
    prop = get_device_properties(device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/cuda/__init__.py", line 616, in get_device_properties
    _lazy_init()  # will define _get_device_properties
    ^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/cuda/__init__.py", line 403, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
