### PR TITLE
BUG: Fix issue where serialization and deserialization fail due to inconsistent NumPy versions between the virtual environment and the system environment

### DIFF
--- a/python/xoscar/serialization/aio.py
+++ b/python/xoscar/serialization/aio.py
@@ -19,7 +19,6 @@ from io import BytesIO
 from typing import Any, BinaryIO, Union
 
 import cloudpickle
-import numpy as np
 
 from ..utils import lazy_import
 from .core import deserialize, serialize_with_spawn


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

修改AioDeserializer类中序列化header的 is_cuda_buffer 字段时的类型，将numpy.array 修改为 list；避免系统环境和虚拟环境numpy版本不一致导致的反序列化失败问题

future: <Task finished name='Task-12' coro=<UnixSocketServer.create.<locals>.handle_connection() done, defined at /usr/local/lib/python3.10/dist-packages/xoscar/backends/communication/socket.py:386> exception=ModuleNotFoundError("No module named 'numpy._core.numeric'")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/xoscar/backends/communication/socket.py", line 388, in handle_connection
    return await server.on_connected(
  File "/usr/local/lib/python3.10/dist-packages/xoscar/backends/communication/socket.py", line 184, in on_connected
    await self.channel_handler(channel)
  File "/usr/local/lib/python3.10/dist-packages/xoscar/backends/pool.py", line 577, in on_new_channel
    message = await channel.recv()
  File "/usr/local/lib/python3.10/dist-packages/xoscar/backends/communication/socket.py", line 102, in recv
    header = await deserializer.get_header()
  File "/usr/local/lib/python3.10/dist-packages/xoscar/serialization/aio.py", line 142, in get_header
    return cloudpickle.loads(await self._get_obj_header_bytes())
ModuleNotFoundError: No module named 'numpy._core.numeric'
Task exception was never retrieved

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
