### PR TITLE
FEAT: support dynamic variable substitution in virtualenv requirements

### DIFF
--- a/python/xoscar/virtualenv/tests/test_core.py
+++ b/python/xoscar/virtualenv/tests/test_core.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 import pytest
 from packaging.markers import default_environment
 
-from ..core import VirtualEnvManager, filter_requirements
+from ..core import VirtualEnvManager, filter_requirements, substitute_variables
 
 
 def test_system_package_with_plus_cpu():
@@ -131,3 +131,118 @@ def test_filter_requirements_with_combined_markers(
     with patch("xoscar.virtualenv.core.get_env", return_value=std_env):
         filtered = filter_requirements(input_pkgs)
         assert set(filtered) == set(expected_pkgs)
+
+
+class TestSubstituteVariables:
+    """Test #var# substitution in markers."""
+
+    def test_string_variable(self):
+        """Test string variable substitution."""
+        result = substitute_variables('#engine# == "vllm"', {"engine": "vllm"})
+        assert result == '"vllm" == "vllm"'
+
+    def test_string_variable_no_match(self):
+        """Test when variable value doesn't match."""
+        result = substitute_variables('#engine# == "vllm"', {"engine": "sglang"})
+        assert result == '"sglang" == "vllm"'
+
+    def test_numeric_variable(self):
+        """Test numeric variable substitution."""
+        result = substitute_variables("#count# > 5", {"count": 10})
+        assert result == "10 > 5"
+
+    def test_boolean_variable_true(self):
+        """Test boolean variable substitution (True)."""
+        result = substitute_variables("#enabled# == True", {"enabled": True})
+        assert result == "True == True"
+
+    def test_boolean_variable_false(self):
+        """Test boolean variable substitution (False)."""
+        result = substitute_variables("#enabled# == True", {"enabled": False})
+        assert result == "False == True"
+
+    def test_none_variable(self):
+        """Test None variable substitution."""
+        result = substitute_variables("#value# == None", {"value": None})
+        assert result == "None == None"
+
+    def test_string_with_quotes(self):
+        """Test string variable with quotes gets escaped."""
+        result = substitute_variables('#engine# == "test"', {"engine": 'my"engine'})
+        assert result == '"my\\"engine" == "test"'
+
+    def test_multiple_variables(self):
+        """Test multiple variables in one marker."""
+        result = substitute_variables(
+            '#engine# == "vllm" and #mode# == "local"',
+            {"engine": "vllm", "mode": "local"},
+        )
+        assert result == '"vllm" == "vllm" and "local" == "local"'
+
+    def test_no_placeholder(self):
+        """Test marker without placeholder remains unchanged."""
+        result = substitute_variables("has_cuda", {"engine": "vllm"})
+        assert result == "has_cuda"
+
+    def test_variable_not_provided(self):
+        """Test when placeholder exists but variable not provided."""
+        result = substitute_variables('#engine# == "vllm"', {"mode": "local"})
+        # Should not replace since 'engine' is not in variables
+        assert result == '#engine# == "vllm"'
+
+
+class TestFilterRequirementsWithVariables:
+    """Test filter_requirements with dynamic variable substitution."""
+
+    @pytest.mark.parametrize(
+        "variables, input_pkgs, expected_pkgs",
+        [
+            # Simple string match
+            (
+                {"engine": "vllm"},
+                ['pkg1; #engine# == "vllm"', 'pkg2; #engine# == "sglang"'],
+                ["pkg1"],
+            ),
+            # Numeric comparison
+            (
+                {"count": 10},
+                ["pkg1; #count# > 5", "pkg2; #count# < 5"],
+                ["pkg1"],
+            ),
+            # Boolean check
+            (
+                {"enabled": True},
+                ["pkg1; #enabled# == True", "pkg2; #enabled# == False"],
+                ["pkg1"],
+            ),
+            # Multiple variables with AND
+            (
+                {"engine": "vllm", "mode": "local"},
+                [
+                    'pkg1; #engine# == "vllm" and #mode# == "local"',
+                    'pkg2; #engine# == "sglang" or #mode# == "remote"',
+                ],
+                ["pkg1"],
+            ),
+            # No match - empty result
+            (
+                {"engine": "sglang"},
+                ['pkg1; #engine# == "vllm"', 'pkg2; #engine# == "sglang"'],
+                ["pkg2"],
+            ),
+        ],
+    )
+    def test_variable_substitution(self, variables, input_pkgs, expected_pkgs):
+        """Test that #var# placeholders are correctly substituted and filtered."""
+        filtered = filter_requirements(input_pkgs, **variables)
+        assert set(filtered) == set(expected_pkgs)
+
+    def test_variables_with_standard_markers(self):
+        """Test dynamic variables work alongside standard markers."""
+        std_env = default_environment()
+        with patch("xoscar.virtualenv.core.get_env", return_value=std_env):
+            filtered = filter_requirements(
+                ['pkg1; #engine# == "vllm" and python_version >= "3.8"'], engine="vllm"
+            )
+            # Should match if python_version >= 3.8 (which is likely true in test env)
+            assert filtered == ["pkg1"]

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -233,17 +233,26 @@ class UVVirtualEnvManager(VirtualEnvManager):
     def install_packages(self, packages: list[str], **kwargs):
         """
         Install packages into the virtual environment using uv.
-        Supports pip-compatible kwargs: index_url, extra_index_url, find_links.
+
+        Args:
+            packages: List of package specifications
+            **kwargs: Can include:
+                - Pip configuration: index_url, extra_index_url, find_links, trusted_host,
+                  no_build_isolation, log, skip_installed
+                - Dynamic variables for #var# substitution: e.g., engine='vllm', mode='remote'
         """
         if not packages:
             return
 
-        packages = self.process_packages(packages)
+        # Pop pip configuration parameters, remaining kwargs are for variable substitution
+        log = kwargs.pop("log", False)
+        skip_installed = kwargs.pop("skip_installed", SKIP_INSTALLED)
+
+        # Process packages with variable substitution
+        packages = self.process_packages(packages, **kwargs)
         if not packages:
             return
 
-        log = kwargs.pop("log", False)
-        skip_installed = kwargs.pop("skip_installed", SKIP_INSTALLED)
         uv_path = self._get_uv_path()
 
         if skip_installed:


### PR DESCRIPTION
Add support for #var# placeholder syntax in package requirements to enable conditional package installation based on runtime variables.

Features:
- New substitute_variables() function to replace #var# placeholders with actual values
- Enhanced filter_requirements() to accept **variables parameter
- Updated process_packages() and install_packages() to pass variables through
- Supports string, numeric, boolean, and None variable types
- Variables are automatically formatted (strings are quoted and escaped)

Usage example:
  install_packages([ 'transformers==4.30.0; #engine# == "vllm"', 'transformers==4.25.0; #engine# == "sglang"' ], engine='vllm') # Only installs transformers==4.30.0

Tests:
- Added 16 unit tests in test_core.py
- Added 6 end-to-end tests in test_uv.py
- All tests passing

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
