### PR TITLE
ENH : enrich error message for uv virtualenv

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -224,8 +224,7 @@ class CMakeBuild(build_ext):
                 # that the right extensions for the current Python/platform are
                 # used.
                 copy_file(
-                    src_filename, dest_filename, verbose=self.verbose,
-                    dry_run=self.dry_run
+                    src_filename, dest_filename, verbose=self.verbose
                 )
                 if ext._needs_stub:
                     self.write_stub(package_dir or os.curdir, ext, True)
@@ -238,8 +237,7 @@ class CMakeBuild(build_ext):
                 dest_filename = os.path.join(collective_dir,
                                                 os.path.basename(filename))
                 copy_file(
-                    src_filename, dest_filename, verbose=self.verbose,
-                    dry_run=self.dry_run
+                    src_filename, dest_filename, verbose=self.verbose
                 )
 
 
@@ -371,14 +369,12 @@ class CMakeBuild(build_ext):
                     dest_filename = os.path.join(dest_dir,
                                             os.path.basename(file))
                     move_file(
-                        src_filename, dest_filename, verbose=self.verbose,
-                        dry_run=self.dry_run
+                        src_filename, dest_filename, verbose=self.verbose
                     )
                     libuv_filename = "xoscar\\collective\\uv.dll"
                     libuv_dest_filename = os.path.join(dest_dir, "uv.dll")
                     copy_file(
-                        libuv_filename, libuv_dest_filename, verbose=self.verbose,
-                        dry_run=self.dry_run
+                        libuv_filename, libuv_dest_filename, verbose=self.verbose
                     )
 
 

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -137,8 +137,11 @@ class UVVirtualEnvManager(VirtualEnvManager):
                 f.name,
                 *specs,
             ]
-            result = subprocess.run(cmd, check=True, text=True, capture_output=True)
-
+            try:
+                result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+            except subprocess.CalledProcessError as e:
+                logger.error(e.stderr)
+                raise e
         # the temp file is automatically deleted here
         deps = [
             f"{m.group(1)}=={m.group(2)}"


### PR DESCRIPTION
uv安装依赖时：result = subprocess.run(cmd, check=True, text=True, capture_output=True)，由于同时配置了capture_output，以及check，导致安装错误时会直接抛出异常subprocess.CalledProcessError，仅能获取报错信息returned non-zero exit status 1. 丢失uv安装的具体报错信息。

本提交增加对异常报错进行捕获并输出到日志；相关代码已经自测