### PR TITLE
DOC: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Xoscar, please report
+it privately through GitHub Security Advisories:
+
+[GitHub Security Advisories](https://github.com/xorbitsai/xoscar/security/advisories/new)
+
+We follow a coordinated vulnerability disclosure process and appreciate
+responsible security research.
+
+Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.
+
+When submitting a report, please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+- Suggested mitigation or fix, if available
+
+We will acknowledge receipt as soon as possible and work with you to validate
+and resolve the issue.
+
+## Public Disclosure
+
+Please avoid publicly disclosing vulnerability details until a fix has been
+released or we have coordinated disclosure together.
+
+## Security Updates
+
+Security fixes may be released through normal project releases and GitHub
+Security Advisories.


### PR DESCRIPTION
## Summary

- Add a SECURITY.md policy for Xoscar.
- Direct vulnerability reports to GitHub Security Advisories for xorbitsai/xoscar.

## Validation

- `git diff --cached --check`
- Commit hooks ran; code-format and lint hooks skipped because this is a Markdown-only change.