### PR TITLE
BUG: resolve specs with extras in uv skip_installed even if base package is installed

### DIFF
--- a/python/xoscar/virtualenv/tests/test_uv.py
+++ b/python/xoscar/virtualenv/tests/test_uv.py
@@ -313,6 +313,22 @@ def test_uv_virtualenv_exists_env():
         assert not os.path.exists(path)
 
 
+def test_split_specs_with_extras():
+    """Specs with extras must be resolved even if the base package is installed,
+    since a bare install may lack the extra dependencies."""
+    installed = {"sglang": "0.5.7", "requests": "2.28.0"}
+
+    keep, to_resolve, pinned = UVVirtualEnvManager._split_specs(
+        ["sglang[diffusion]", "requests[socks]>=2.0", "requests"], installed
+    )
+
+    assert keep == []
+    # both extras specs go to the resolver despite the base packages being installed
+    assert to_resolve == ["sglang[diffusion]", "requests[socks]>=2.0"]
+    # the plain spec satisfied by the installed version is pinned
+    assert pinned == {"requests": "2.28.0"}
+
+
 @pytest.fixture
 def uv_manager(tmp_path):
     env_path = tmp_path / "test_env"

--- a/python/xoscar/virtualenv/tests/test_uv.py
+++ b/python/xoscar/virtualenv/tests/test_uv.py
@@ -315,18 +315,31 @@ def test_uv_virtualenv_exists_env():
 
 def test_split_specs_with_extras():
     """Specs with extras must be resolved even if the base package is installed,
-    since a bare install may lack the extra dependencies."""
-    installed = {"sglang": "0.5.7", "requests": "2.28.0"}
+    since a bare install may lack the extra dependencies. The satisfied base
+    distribution is pinned so the resolver only adds the missing extra deps."""
+    installed = {"sglang": "0.5.7", "requests": "2.28.0", "oldpkg": "1.0"}
 
     keep, to_resolve, pinned = UVVirtualEnvManager._split_specs(
-        ["sglang[diffusion]", "requests[socks]>=2.0", "requests"], installed
+        [
+            "sglang[diffusion]",
+            "requests[socks]>=2.0",
+            "oldpkg[x]>=2.0",
+            "newpkg[y]",
+        ],
+        installed,
     )
 
     assert keep == []
-    # both extras specs go to the resolver despite the base packages being installed
-    assert to_resolve == ["sglang[diffusion]", "requests[socks]>=2.0"]
-    # the plain spec satisfied by the installed version is pinned
-    assert pinned == {"requests": "2.28.0"}
+    # all extras specs go to the resolver despite the base packages being installed
+    assert to_resolve == [
+        "sglang[diffusion]",
+        "requests[socks]>=2.0",
+        "oldpkg[x]>=2.0",
+        "newpkg[y]",
+    ]
+    # installed base distributions satisfying the specifier are pinned so the
+    # resolver won't upgrade them; unsatisfied or missing ones are left free
+    assert pinned == {"sglang": "0.5.7", "requests": "2.28.0"}
 
 
 @pytest.fixture

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -194,6 +194,14 @@ class UVVirtualEnvManager(VirtualEnvManager):
             name = req.name.lower()
             cur_ver = installed.get(name)
 
+            if req.extras:
+                # The installed distribution may lack the extra dependencies
+                # (e.g. "sglang[diffusion]" vs a bare "sglang" install), so let
+                # the resolver figure out what is actually missing; already
+                # satisfied packages stay locked via the pinned constraints.
+                to_resolve.append(spec_str)
+                continue
+
             if cur_ver is None:
                 # Package not installed, needs resolution
                 to_resolve.append(spec_str)

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -197,8 +197,18 @@ class UVVirtualEnvManager(VirtualEnvManager):
             if req.extras:
                 # The installed distribution may lack the extra dependencies
                 # (e.g. "sglang[diffusion]" vs a bare "sglang" install), so let
-                # the resolver figure out what is actually missing; already
-                # satisfied packages stay locked via the pinned constraints.
+                # the resolver figure out what is actually missing. Pin the
+                # installed base distribution when it already satisfies the
+                # requirement so the resolver only adds the missing extra
+                # dependencies instead of upgrading the base package.
+                if cur_ver is not None:
+                    try:
+                        if not req.specifier or Version(cur_ver) in req.specifier:
+                            pinned[name] = cur_ver
+                    except Exception:
+                        # Parsing error, leave it unpinned and let the
+                        # resolver decide
+                        pass
                 to_resolve.append(spec_str)
                 continue
 


### PR DESCRIPTION
## What do these changes do?

With `skip_installed` enabled, `UVVirtualEnvManager._split_specs` decides whether a requirement is already satisfied by the parent environment using only the distribution name and version:

```python
req = Requirement(spec_str)
name = req.name.lower()
cur_ver = installed.get(name)
```

`req.extras` is ignored, so a spec like `sglang[diffusion]` is treated as satisfied whenever a bare `sglang` is installed in the parent environment. The spec is then never passed to the resolver, nothing gets installed into the virtual environment, and imports fall back to the parent environment's bare package whose extra dependencies are missing.

Real-world impact (verified with xinference's SGLang image engine): the host had a bare `sglang==0.5.7`, the virtualenv spec `sglang[diffusion]` was skipped, and model loading crashed with `ModuleNotFoundError: No module named 'remote_pdb'` — one of the 13 dependencies pulled in by the `[diffusion]` extra.

### Fix

In `_split_specs`, when `req.extras` is non-empty, always route the spec to `to_resolve` and let the resolver compute the actually-missing extra dependencies. Already-satisfied packages remain locked via the pinned constraints, and `_filter_packages_not_installed` still drops any resolved package whose exact version is already installed, so only the genuinely missing extra dependencies get installed.

### Test

Added `test_split_specs_with_extras`: with a fake installed mapping containing bare `sglang` and `requests`, specs `sglang[diffusion]` and `requests[socks]>=2.0` are routed to `to_resolve`, while a plain satisfied `requests` spec is still pinned.

## Check code requirements

- [x] tests added / passed (`pytest xoscar/virtualenv/tests/test_uv.py -k "marker_filtering or split_specs"`)
- [x] passes `pre-commit run --files python/xoscar/virtualenv/uv.py python/xoscar/virtualenv/tests/test_uv.py`