### PR TITLE
ENH: graceful fallback for #system_*# when host package is missing

### DIFF
--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import ast
 import importlib
 import json
+import logging
 import operator
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -33,10 +34,16 @@ from .platform import (
 )
 from .utils import is_vcs_url
 
+logger = logging.getLogger(__name__)
 
-def resolve_system_requirement(req_part: str) -> str:
+
+def is_system_requirement(req_part: str) -> bool:
+    return req_part.startswith("#system_") and req_part.endswith("#")
+
+
+def resolve_system_requirement(req_part: str, warn: bool = True) -> str:
     req_part = req_part.strip()
-    if not (req_part.startswith("#system_") and req_part.endswith("#")):
+    if not is_system_requirement(req_part):
         return req_part
 
     real_pkg = req_part[len("#system_") : -1]
@@ -44,10 +51,36 @@ def resolve_system_requirement(req_part: str) -> str:
         version = importlib.metadata.version(real_pkg)
         version = version.split("+")[0]
     except importlib.metadata.PackageNotFoundError:
-        raise RuntimeError(
-            f"System package '{real_pkg}' not found. Cannot resolve '{req_part}'."
-        )
+        # The placeholder exists to keep the virtualenv aligned with the host
+        # environment; if the host doesn't have the package, there is nothing
+        # to align with, so install it unpinned instead of failing.
+        if warn:
+            logger.warning(
+                "System package '%s' not found in the host environment, "
+                "'%s' will be installed without version pinning.",
+                real_pkg,
+                req_part,
+            )
+        return real_pkg
     return f"{real_pkg}=={version}"
+
+
+def collect_system_pins(packages: list[str]) -> set[str]:
+    """
+    Return the pinned specs (e.g. {"numpy==1.26.4"}) that #system_<package>#
+    placeholders in ``packages`` resolve to in the current host environment.
+
+    Placeholders whose package is not installed on the host resolve to an
+    unpinned name and are not included.
+    """
+    pins = set()
+    for pkg in packages:
+        req_part = pkg.split(";", 1)[0].strip()
+        if is_system_requirement(req_part):
+            resolved = resolve_system_requirement(req_part, warn=False)
+            if "==" in resolved:
+                pins.add(resolved)
+    return pins
 
 
 class VirtualEnvManager(ABC):
@@ -88,9 +121,8 @@ class VirtualEnvManager(ABC):
 
         Returns:
             list[str]: A new list with resolved package names and versions.
-
-        Raises:
-            RuntimeError: If a specified system package is not found in the environment.
+            Placeholders whose package is missing from the host environment
+            resolve to the unpinned package name.
         """
         processed = []
 
@@ -300,10 +332,25 @@ def filter_requirements(requirements: list[str], **variables) -> list[str]:
         elif ";" in req_str:
             req_part, marker_part = req_str.split(";", 1)
             marker_part = marker_part.strip()
-            req_part = resolve_system_requirement(req_part.strip())
+            req_part = req_part.strip()
 
             # Substitute #var# placeholders with actual values
             marker_part = substitute_variables(marker_part, variables)
+
+            if is_system_requirement(req_part):
+                # A #system_*# placeholder is not a valid Requirement, so
+                # evaluate its marker separately; resolve the placeholder only
+                # if the entry is kept, to avoid spurious not-found warnings
+                # for entries that get filtered out anyway.
+                try:
+                    keep = Marker(marker_part).evaluate(env)
+                except Exception:
+                    keep = is_custom_marker(marker_part) and eval_custom_marker(
+                        marker_part, env
+                    )
+                if keep:
+                    result.append(resolve_system_requirement(req_part))
+                continue
 
             try:
                 req = Requirement(f"{req_part}; {marker_part}")
@@ -327,7 +374,7 @@ def filter_requirements(requirements: list[str], **variables) -> list[str]:
                 else:
                     raise
         else:
-            req = Requirement(req_str.strip())
+            req = Requirement(resolve_system_requirement(req_str))
             result.append(str(req))
 
     return result

--- a/python/xoscar/virtualenv/core.py
+++ b/python/xoscar/virtualenv/core.py
@@ -65,6 +65,20 @@ def resolve_system_requirement(req_part: str, warn: bool = True) -> str:
     return f"{real_pkg}=={version}"
 
 
+def relax_system_requirement(req_str: str) -> str:
+    """
+    Replace the #system_<pkg># placeholder in a requirement string with the
+    bare package name (keeping any marker), dropping host alignment.
+    Non-placeholder requirements are returned unchanged.
+    """
+    req_part, sep, marker_part = req_str.partition(";")
+    stripped = req_part.strip()
+    if not is_system_requirement(stripped):
+        return req_str
+    bare = stripped[len("#system_") : -1]
+    return f"{bare} ;{marker_part}" if sep else bare
+
+
 def collect_system_pins(packages: list[str]) -> set[str]:
     """
     Return the pinned specs (e.g. {"numpy==1.26.4"}) that #system_<package>#

--- a/python/xoscar/virtualenv/tests/test_core.py
+++ b/python/xoscar/virtualenv/tests/test_core.py
@@ -104,6 +104,42 @@ def test_collect_system_pins_missing_package(caplog):
     assert "notexist" not in caplog.text
 
 
+def test_relax_system_requirement():
+    from ..core import relax_system_requirement
+
+    assert relax_system_requirement("#system_numpy#") == "numpy"
+    assert (
+        relax_system_requirement('#system_numpy# ; #engine# == "vllm"')
+        == 'numpy ; #engine# == "vllm"'
+    )
+    # non-placeholder requirements are untouched, pinned or not
+    assert relax_system_requirement("numpy==1.26.4") == "numpy==1.26.4"
+    assert relax_system_requirement("vllm>=0.11.2") == "vllm>=0.11.2"
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "python_version >",  # unparseable
+        "python_version == 3",  # invalid standard marker, valid python expr
+        'python_version >= "abc"',  # parses, evaluation raises
+    ],
+)
+def test_malformed_marker_system_path_matches_plain_path(marker):
+    # malformed markers must behave the same for #system_*# placeholders
+    # as for plain requirements (either both raise or both drop)
+    def run(req):
+        try:
+            return ("ok", bool(filter_requirements([req])))
+        except Exception as e:
+            return ("raise", type(e).__name__)
+
+    with patch("importlib.metadata.version", return_value="1.26.4"):
+        system_result = run(f"#system_numpy# ; {marker}")
+        plain_result = run(f"requests ; {marker}")
+    assert system_result == plain_result
+
+
 def test_system_package_with_custom_marker():
     with patch("importlib.metadata.version", return_value="2.1.2+cpu"):
         with patch(

--- a/python/xoscar/virtualenv/tests/test_core.py
+++ b/python/xoscar/virtualenv/tests/test_core.py
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 import pytest
 from packaging.markers import default_environment
 
-from ..core import VirtualEnvManager, filter_requirements, substitute_variables
+from ..core import (
+    VirtualEnvManager,
+    collect_system_pins,
+    filter_requirements,
+    substitute_variables,
+)
 
 
 def test_system_package_with_plus_cpu():
@@ -39,10 +45,75 @@ def test_non_placeholder_package():
     assert result == ["requests>=2.0.0"]
 
 
-def test_package_not_found():
+def test_package_not_found_falls_back_unpinned(caplog):
     with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
-        with pytest.raises(RuntimeError, match="System package 'notexist' not found"):
-            VirtualEnvManager.process_packages(["#system_notexist#"])
+        with caplog.at_level(logging.WARNING, logger="xoscar.virtualenv.core"):
+            result = VirtualEnvManager.process_packages(["#system_notexist#"])
+    assert result == ["notexist"]
+    assert "not found in the host environment" in caplog.text
+
+
+def test_system_package_with_marker_filtered_out(caplog):
+    # the entry is dropped by its marker, so the missing host package
+    # must not be looked up at all (no warning)
+    with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        with caplog.at_level(logging.WARNING, logger="xoscar.virtualenv.core"):
+            result = filter_requirements(
+                ['#system_notexist# ; #engine# == "vllm"'], engine="transformers"
+            )
+    assert result == []
+    assert "notexist" not in caplog.text
+
+
+def test_system_package_with_marker_matched_but_not_installed(caplog):
+    with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        with caplog.at_level(logging.WARNING, logger="xoscar.virtualenv.core"):
+            result = filter_requirements(
+                ['#system_notexist# ; #engine# == "vllm"'], engine="vllm"
+            )
+    assert result == ["notexist"]
+    assert "not found in the host environment" in caplog.text
+
+
+def test_system_package_with_marker_matched_and_installed():
+    with patch("importlib.metadata.version", return_value="1.26.4"):
+        result = filter_requirements(
+            ['#system_numpy# ; #engine# == "vllm"'], engine="vllm"
+        )
+    assert result == ["numpy==1.26.4"]
+
+
+def test_collect_system_pins():
+    with patch("importlib.metadata.version", return_value="1.26.4"):
+        pins = collect_system_pins(
+            [
+                "#system_numpy#",
+                '#system_torch# ; #engine# == "vllm"',
+                "vllm==0.21.0",
+                "transformers>=4.50.0",
+            ]
+        )
+    assert pins == {"numpy==1.26.4", "torch==1.26.4"}
+
+
+def test_collect_system_pins_missing_package(caplog):
+    with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        with caplog.at_level(logging.WARNING, logger="xoscar.virtualenv.core"):
+            assert collect_system_pins(["#system_notexist#"]) == set()
+    # collecting pins must not duplicate the not-found warning
+    assert "notexist" not in caplog.text
+
+
+def test_system_package_with_custom_marker():
+    with patch("importlib.metadata.version", return_value="2.1.2+cpu"):
+        with patch(
+            "xoscar.virtualenv.core.get_env",
+            return_value={**default_environment(), "has_cuda": True},
+        ):
+            assert filter_requirements(["#system_torch# ; has_cuda"]) == [
+                "torch==2.1.2"
+            ]
+            assert filter_requirements(["#system_torch# ; not has_cuda"]) == []
 
 
 @pytest.mark.parametrize(

--- a/python/xoscar/virtualenv/tests/test_core.py
+++ b/python/xoscar/virtualenv/tests/test_core.py
@@ -120,7 +120,7 @@ def test_relax_system_requirement():
 @pytest.mark.parametrize(
     "marker",
     [
-        "python_version >",  # unparseable
+        "python_version >",  # unparsable
         "python_version == 3",  # invalid standard marker, valid python expr
         'python_version >= "abc"',  # parses, evaluation raises
     ],

--- a/python/xoscar/virtualenv/tests/test_uv.py
+++ b/python/xoscar/virtualenv/tests/test_uv.py
@@ -544,3 +544,39 @@ def test_install_packages_retry_also_fails(uv_manager):
         with pytest.raises(subprocess.CalledProcessError):
             uv_manager.install_packages(["#system_numpy#", "vllm==0.21.0"])
         assert mock_popen.call_count == 2
+
+
+def test_install_packages_no_retry_after_cancel(uv_manager):
+    # cancel_install terminates uv, which also exits non-zero; that must not
+    # be mistaken for a resolver conflict and trigger the pin-drop retry
+    import subprocess
+
+    calls = []
+
+    class FakeProcess:
+        def __init__(self):
+            self._terminated = False
+
+        def poll(self):
+            return -15 if self._terminated else None
+
+        def terminate(self):
+            self._terminated = True
+
+        def wait(self):
+            if not self._terminated:
+                # simulate the user cancelling while uv is running
+                uv_manager.cancel_install()
+            return -15
+
+    def fake_popen(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        return FakeProcess()
+
+    with mock.patch("importlib.metadata.version", return_value="1.26.4"), mock.patch(
+        "subprocess.Popen", side_effect=fake_popen
+    ), mock.patch.object(UVVirtualEnvManager, "_get_uv_path", return_value="uv"):
+        with pytest.raises(subprocess.CalledProcessError):
+            uv_manager.install_packages(["#system_numpy#", "vllm==0.21.0"])
+
+    assert len(calls) == 1

--- a/python/xoscar/virtualenv/tests/test_uv.py
+++ b/python/xoscar/virtualenv/tests/test_uv.py
@@ -546,6 +546,31 @@ def test_install_packages_retry_also_fails(uv_manager):
         assert mock_popen.call_count == 2
 
 
+def test_install_packages_retry_keeps_identical_explicit_pin(uv_manager):
+    # an explicit user/spec pin spelling the same version as the resolved
+    # #system_*# placeholder must survive the retry; only the
+    # placeholder-derived entry is relaxed
+    calls = []
+
+    def fake_popen(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        process = mock.Mock()
+        process.wait.return_value = 1 if len(calls) == 1 else 0
+        return process
+
+    with mock.patch("importlib.metadata.version", return_value="1.26.4"), mock.patch(
+        "subprocess.Popen", side_effect=fake_popen
+    ), mock.patch.object(UVVirtualEnvManager, "_get_uv_path", return_value="uv"):
+        uv_manager.install_packages(["#system_numpy#", "numpy==1.26.4", "vllm==0.21.0"])
+
+    assert len(calls) == 2
+    # the placeholder-derived pin is relaxed to a bare name...
+    assert "numpy" in calls[1]
+    # ...while the explicit identical pin is preserved
+    assert "numpy==1.26.4" in calls[1]
+    assert "vllm==0.21.0" in calls[1]
+
+
 def test_install_packages_no_retry_after_cancel(uv_manager):
     # cancel_install terminates uv, which also exits non-zero; that must not
     # be mistaken for a resolver conflict and trigger the pin-drop retry

--- a/python/xoscar/virtualenv/tests/test_uv.py
+++ b/python/xoscar/virtualenv/tests/test_uv.py
@@ -485,3 +485,62 @@ def test_variable_substitution_in_install_packages(
                     assert (
                         base_pkg not in cmd_str
                     ), f"Unexpected package '{base_pkg}' found in command: {cmd_str}"
+
+
+def test_install_packages_retry_without_system_pins(uv_manager, caplog):
+    # first uv invocation fails (simulating a resolver conflict with the
+    # host-aligned pin), the retry without pins succeeds
+    calls = []
+
+    def fake_popen(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        process = mock.Mock()
+        process.wait.return_value = 1 if len(calls) == 1 else 0
+        return process
+
+    with mock.patch("importlib.metadata.version", return_value="1.26.4"), mock.patch(
+        "subprocess.Popen", side_effect=fake_popen
+    ), mock.patch.object(UVVirtualEnvManager, "_get_uv_path", return_value="uv"):
+        with caplog.at_level(logging.WARNING, logger="xoscar.virtualenv.uv"):
+            uv_manager.install_packages(["#system_numpy#", "vllm==0.21.0"])
+
+    assert len(calls) == 2
+    assert "numpy==1.26.4" in calls[0]
+    assert "numpy==1.26.4" not in calls[1]
+    assert "numpy" in calls[1]
+    # explicit user/spec pins are never dropped
+    assert "vllm==0.21.0" in calls[1]
+    assert "retrying without them" in caplog.text
+
+
+def test_install_packages_failure_without_system_pins_reraises(uv_manager):
+    import subprocess
+
+    with mock.patch("subprocess.Popen") as mock_popen, mock.patch.object(
+        UVVirtualEnvManager, "_get_uv_path", return_value="uv"
+    ):
+        process = mock.Mock()
+        process.wait.return_value = 1
+        mock_popen.return_value = process
+
+        with pytest.raises(subprocess.CalledProcessError):
+            uv_manager.install_packages(["vllm==0.21.0"])
+        # no system pins involved, so no retry
+        assert mock_popen.call_count == 1
+
+
+def test_install_packages_retry_also_fails(uv_manager):
+    import subprocess
+
+    with mock.patch("importlib.metadata.version", return_value="1.26.4"), mock.patch(
+        "subprocess.Popen"
+    ) as mock_popen, mock.patch.object(
+        UVVirtualEnvManager, "_get_uv_path", return_value="uv"
+    ):
+        process = mock.Mock()
+        process.wait.return_value = 1
+        mock_popen.return_value = process
+
+        with pytest.raises(subprocess.CalledProcessError):
+            uv_manager.install_packages(["#system_numpy#", "vllm==0.21.0"])
+        assert mock_popen.call_count == 2

--- a/python/xoscar/virtualenv/tests/test_uv.py
+++ b/python/xoscar/virtualenv/tests/test_uv.py
@@ -571,6 +571,53 @@ def test_install_packages_retry_keeps_identical_explicit_pin(uv_manager):
     assert "vllm==0.21.0" in calls[1]
 
 
+def test_install_packages_retry_skip_installed_does_not_repin(uv_manager):
+    # with skip_installed=True the retry must not let _split_specs pin the
+    # relaxed placeholder back to the installed host version, otherwise the
+    # second dry-run reuses the exact constraint that just failed
+    import subprocess
+
+    class FakeDist:
+        metadata = {"Name": "numpy"}
+        version = "1.26.4"
+
+    plan_calls = []
+
+    def fake_resolve(self, specs, pinned, *args, **kwargs):
+        plan_calls.append((list(specs), dict(pinned)))
+        if len(plan_calls) == 1:
+            raise subprocess.CalledProcessError(1, "uv")
+        return ["numpy==2.1.0", "vllm==0.21.0"]
+
+    def fake_popen(cmd, *args, **kwargs):
+        process = mock.Mock()
+        process.wait.return_value = 0
+        return process
+
+    with mock.patch("importlib.metadata.version", return_value="1.26.4"), mock.patch(
+        "xoscar.virtualenv.uv.distributions", return_value=[FakeDist()]
+    ), mock.patch.object(
+        UVVirtualEnvManager, "_resolve_install_plan", autospec=True
+    ) as mock_plan, mock.patch(
+        "subprocess.Popen", side_effect=fake_popen
+    ), mock.patch.object(
+        UVVirtualEnvManager, "_get_uv_path", return_value="uv"
+    ):
+        mock_plan.side_effect = fake_resolve
+        uv_manager.install_packages(
+            ["#system_numpy#", "vllm==0.21.0"], skip_installed=True
+        )
+
+    assert len(plan_calls) == 2
+    # first attempt: the placeholder resolves to the host pin, so numpy is
+    # satisfied and becomes a dry-run constraint
+    assert plan_calls[0] == (["vllm==0.21.0"], {"numpy": "1.26.4"})
+    # retry: numpy is sent to the resolver unconstrained instead of being
+    # re-pinned to the host version
+    assert "numpy" in plan_calls[1][0]
+    assert "numpy" not in plan_calls[1][1]
+
+
 def test_install_packages_no_retry_after_cancel(uv_manager):
     # cancel_install terminates uv, which also exits non-zero; that must not
     # be mistaken for a resolver conflict and trigger the pin-drop retry

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -173,13 +173,19 @@ class UVVirtualEnvManager(VirtualEnvManager):
 
     @staticmethod
     def _split_specs(
-        specs: list[str], installed: dict[str, str]
+        specs: list[str],
+        installed: dict[str, str],
+        relax_names: frozenset[str] = frozenset(),
     ) -> tuple[list[str], list[str], dict[str, str]]:
         """
         Split the given requirement specs into:
         - keep： specs that need to be kept, e.g. git+github://xxx
         - to_resolve: specs that need to be passed to the resolver (unsatisfied ones)
         - pinned: already satisfied specs, used for constraint to lock their versions
+
+        Package names in ``relax_names`` (host-aligned pins dropped by the
+        retry path) are always sent to the resolver instead of being pinned
+        back to the installed host version.
         """
         keep: list[str] = []
         to_resolve: list[str] = []
@@ -193,6 +199,9 @@ class UVVirtualEnvManager(VirtualEnvManager):
 
             req = Requirement(spec_str)
             name = req.name.lower()
+            if name in relax_names:
+                to_resolve.append(spec_str)
+                continue
             cur_ver = installed.get(name)
 
             if cur_ver is None:
@@ -224,6 +233,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
         index_url: str | None = None,
         extra_index_url: str | list[str] | None = None,
         index_strategy: str | None = None,
+        relax_names: frozenset[str] = frozenset(),
     ) -> list[str]:
         """
         Filter out packages that are already installed with the same version.
@@ -237,7 +247,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
         }
 
         # exclude those packages that satisfied in system site packages
-        keep, to_resolve, pinned = self._split_specs(packages, installed)
+        keep, to_resolve, pinned = self._split_specs(packages, installed, relax_names)
         if not keep and not to_resolve:
             logger.debug("All requirement specifiers satisfied by system packages.")
             return []
@@ -290,12 +300,18 @@ class UVVirtualEnvManager(VirtualEnvManager):
             return
         self._install_cancelled = False
 
-        def _do_install(install_list: list[str]) -> None:
+        def _do_install(
+            install_list: list[str], relax_names: frozenset[str] = frozenset()
+        ) -> None:
             uv_path = self._get_uv_path()
 
             if skip_installed:
                 install_list = self._filter_packages_not_installed(
-                    install_list, index_url, extra_index_url, index_strategy
+                    install_list,
+                    index_url,
+                    extra_index_url,
+                    index_strategy,
+                    relax_names,
                 )
                 if not install_list:
                     logger.info("All required packages are already installed.")
@@ -382,13 +398,16 @@ class UVVirtualEnvManager(VirtualEnvManager):
             retry_list = self.process_packages(
                 [relax_system_requirement(pkg) for pkg in raw_packages], **kwargs
             )
+            # In skip_installed mode the relaxed names must not be pinned back
+            # to the installed host versions by _split_specs.
+            relaxed_names = frozenset(p.split("==", 1)[0].lower() for p in pins)
             logger.warning(
                 "Package installation failed with host-aligned pins %s; "
                 "retrying without them. The virtual environment may end up with "
                 "versions different from the host environment.",
                 sorted(pins),
             )
-            _do_install(retry_list)
+            _do_install(retry_list, relaxed_names)
 
     def cancel_install(self):
         if self._install_process and self._install_process.poll() is None:

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -45,6 +45,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
     def __init__(self, env_path: Path):
         super().__init__(env_path)
         self._install_process: Optional[subprocess.Popen] = None
+        self._install_cancelled = False
 
     @classmethod
     def is_available(cls):
@@ -287,6 +288,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
         processed = self.process_packages(packages, **kwargs)
         if not processed:
             return
+        self._install_cancelled = False
 
         def _do_install(install_list: list[str]) -> None:
             uv_path = self._get_uv_path()
@@ -364,6 +366,10 @@ class UVVirtualEnvManager(VirtualEnvManager):
         try:
             _do_install(processed)
         except subprocess.CalledProcessError:
+            # An explicitly cancelled install also exits non-zero; never
+            # start a second install in that case.
+            if self._install_cancelled:
+                raise
             # Host-aligned #system_*# pins can conflict with other requirements,
             # e.g. a model requires a newer engine whose dependencies exceed the
             # host-pinned version. Drop only those pins and retry once.
@@ -383,6 +389,7 @@ class UVVirtualEnvManager(VirtualEnvManager):
 
     def cancel_install(self):
         if self._install_process and self._install_process.poll() is None:
+            self._install_cancelled = True
             self._install_process.terminate()
             self._install_process.wait()
 

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -29,7 +29,7 @@ from typing import Optional
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from .core import VirtualEnvManager
+from .core import VirtualEnvManager, collect_system_pins
 from .utils import is_vcs_url, run_subprocess_with_logger
 
 UV_PATH = os.getenv("XOSCAR_UV_PATH")
@@ -283,79 +283,103 @@ class UVVirtualEnvManager(VirtualEnvManager):
         index_strategy = kwargs.pop("index_strategy", None)
 
         # Process packages with variable substitution
-        packages = self.process_packages(packages, **kwargs)
-        if not packages:
+        raw_packages = packages
+        processed = self.process_packages(packages, **kwargs)
+        if not processed:
             return
 
-        uv_path = self._get_uv_path()
+        def _do_install(install_list: list[str]) -> None:
+            uv_path = self._get_uv_path()
 
-        if skip_installed:
-            packages = self._filter_packages_not_installed(
-                packages, index_url, extra_index_url, index_strategy
-            )
-            if not packages:
-                logger.info("All required packages are already installed.")
-                return
-
-            cmd = [
-                uv_path,
-                "pip",
-                "install",
-                "-p",
-                str(self.env_path),
-                "--color=always",
-                "--no-deps",
-            ] + packages
-        else:
-            cmd = [
-                uv_path,
-                "pip",
-                "install",
-                "-p",
-                str(self.env_path),
-                "--color=always",
-            ] + packages
-
-        if index_url:
-            cmd += ["-i", index_url]
-        param_and_option = [
-            (extra_index_url, "--extra-index-url"),
-            ("find_links" in kwargs and kwargs["find_links"], "-f"),
-            ("trusted_host" in kwargs and kwargs["trusted_host"], "--trusted-host"),
-        ]
-        for param, option in param_and_option:
-            if param:
-                val = (
-                    param
-                    if not isinstance(param, bool)
-                    else kwargs.get(
-                        {"-f": "find_links", "--trusted-host": "trusted_host"}[option]
-                    )
+            if skip_installed:
+                install_list = self._filter_packages_not_installed(
+                    install_list, index_url, extra_index_url, index_strategy
                 )
-                if val:
-                    cmd += (
-                        [option, val]
-                        if isinstance(val, str)
-                        else [opt for v in val for opt in (option, v)]
+                if not install_list:
+                    logger.info("All required packages are already installed.")
+                    return
+
+                cmd = [
+                    uv_path,
+                    "pip",
+                    "install",
+                    "-p",
+                    str(self.env_path),
+                    "--color=always",
+                    "--no-deps",
+                ] + install_list
+            else:
+                cmd = [
+                    uv_path,
+                    "pip",
+                    "install",
+                    "-p",
+                    str(self.env_path),
+                    "--color=always",
+                ] + install_list
+
+            if index_url:
+                cmd += ["-i", index_url]
+            param_and_option = [
+                (extra_index_url, "--extra-index-url"),
+                ("find_links" in kwargs and kwargs["find_links"], "-f"),
+                ("trusted_host" in kwargs and kwargs["trusted_host"], "--trusted-host"),
+            ]
+            for param, option in param_and_option:
+                if param:
+                    val = (
+                        param
+                        if not isinstance(param, bool)
+                        else kwargs.get(
+                            {"-f": "find_links", "--trusted-host": "trusted_host"}[
+                                option
+                            ]
+                        )
                     )
+                    if val:
+                        cmd += (
+                            [option, val]
+                            if isinstance(val, str)
+                            else [opt for v in val for opt in (option, v)]
+                        )
 
-        if index_strategy:
-            cmd += ["--index-strategy", index_strategy]
-        if kwargs.get("no_build_isolation", False):
-            cmd += ["--no-build-isolation"]
+            if index_strategy:
+                cmd += ["--index-strategy", index_strategy]
+            if kwargs.get("no_build_isolation", False):
+                cmd += ["--no-build-isolation"]
 
-        logger.info("Installing packages via command: %s", cmd)
-        if not log:
-            self._install_process = process = subprocess.Popen(cmd)
-            returncode = process.wait()
-        else:
-            with run_subprocess_with_logger(cmd) as process:
-                self._install_process = process
-            returncode = process.returncode
+            logger.info("Installing packages via command: %s", cmd)
+            if not log:
+                self._install_process = process = subprocess.Popen(cmd)
+                returncode = process.wait()
+            else:
+                with run_subprocess_with_logger(cmd) as process:
+                    self._install_process = process
+                returncode = process.returncode
 
-        self._install_process = None
-        if returncode != 0:
-            raise subprocess.CalledProcessError(returncode, cmd)
+            self._install_process = None
+            if returncode != 0:
+                raise subprocess.CalledProcessError(returncode, cmd)
+
+        try:
+            _do_install(processed)
+        except subprocess.CalledProcessError:
+            # Host-aligned #system_*# pins can conflict with other requirements,
+            # e.g. a model requires a newer engine whose dependencies exceed the
+            # host-pinned version. Drop only those pins and retry once.
+            pins = collect_system_pins(raw_packages) & set(processed)
+            if not pins:
+                raise
+            retry_list = [
+                spec.split("==", 1)[0] if spec in pins else spec for spec in processed
+            ]
+            logger.warning(
+                "Package installation failed with host-aligned pins %s; "
+                "retrying without them. The virtual environment may end up with "
+                "versions different from the host environment.",
+                sorted(pins),
+            )
+            _do_install(retry_list)
 
     def cancel_install(self):
         if self._install_process and self._install_process.poll() is None:

--- a/python/xoscar/virtualenv/uv.py
+++ b/python/xoscar/virtualenv/uv.py
@@ -29,7 +29,7 @@ from typing import Optional
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-from .core import VirtualEnvManager, collect_system_pins
+from .core import VirtualEnvManager, collect_system_pins, relax_system_requirement
 from .utils import is_vcs_url, run_subprocess_with_logger
 
 UV_PATH = os.getenv("XOSCAR_UV_PATH")
@@ -376,9 +376,12 @@ class UVVirtualEnvManager(VirtualEnvManager):
             pins = collect_system_pins(raw_packages) & set(processed)
             if not pins:
                 raise
-            retry_list = [
-                spec.split("==", 1)[0] if spec in pins else spec for spec in processed
-            ]
+            # Re-process with the placeholders relaxed to bare names so that
+            # only placeholder-derived pins are dropped; an explicit user/spec
+            # pin that happens to spell the same version is kept.
+            retry_list = self.process_packages(
+                [relax_system_requirement(pkg) for pkg in raw_packages], **kwargs
+            )
             logger.warning(
                 "Package installation failed with host-aligned pins %s; "
                 "retrying without them. The virtual environment may end up with "


### PR DESCRIPTION
## What do these changes do?

Make the `#system_<pkg>#` placeholder syntax work on minimal-install hosts (e.g. Xinference 3.0) where numpy/torch/pandas may not be installed in the main environment.

Three changes in `xoscar/virtualenv`:

1. **Graceful fallback instead of hard failure.** `resolve_system_requirement` used to raise `RuntimeError` when the host environment lacks the package, which aborted the whole install (and model launch in Xinference). Since the placeholder's purpose is aligning the venv with the host version, a missing host package means there is nothing to align with — the package is now installed unpinned with a warning.

2. **Markers are evaluated before placeholder resolution.** `filter_requirements` used to resolve `#system_*#` before evaluating the requirement's marker, so an entry like `#system_pandas# ; #engine# == "vllm"` failed on a pandas-less host even when the engine marker would have filtered it out anyway. Filtered-out entries no longer touch host metadata or emit warnings.

3. **Retry without host-aligned pins on install failure.** A host-aligned pin (e.g. `numpy==1.26.4` from `#system_numpy#`) can conflict with other requirements — e.g. a model pins a newer engine whose dependencies exceed the host version. `UVVirtualEnvManager.install_packages` now retries once with only the `#system_*#`-derived pins dropped (explicit user/spec pins are never touched), with a warning that host alignment was abandoned.

## Related issue number

Discovered while slimming down Xinference 3.0's core dependencies: model specs use `#system_numpy#`/`#system_torch#`/`#system_pandas#` extensively, and any of them missing from the host hard-failed model launch.

## Check code requirements

- [x] tests added / passed (updated `test_core.py`, new retry tests in `test_uv.py`)
- [x] passes `black --check`, `isort --check-only`, `flake8`