### PR TITLE
DOC: fix Read the Docs build by updating build image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@ sphinx:
    configuration: doc/source/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
   apt_packages:
     - cmake
 


### PR DESCRIPTION
## What do these changes do?

All recent Read the Docs builds (including `latest` and PR builds) have been failing at the config validation stage, before any build command runs. The build notification shows:

> Config validation error in `build.os`. Expected one of (ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest), got `ubuntu-20.04`.

Read the Docs has dropped support for the `ubuntu-20.04` build image, so every build fails immediately with no command output.

This PR updates `.readthedocs.yaml`:

- `build.os`: `ubuntu-20.04` → `ubuntu-22.04`
- `build.tools.python`: `3.9` → `3.11` (Python 3.9 is EOL; 3.11 is covered by the CI matrix)

Verified locally: the Sphinx build (`doc/source`) succeeds with the latest `sphinx` and `pydata-sphinx-theme`, including the `autosummary` reference pages, so no other doc changes are needed.

## Related issue number

N/A