### PR TITLE
BUG: skip unavailable lazy serialization handlers

### DIFF
--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -66,8 +66,12 @@ cdef class TypeDispatcher:
             self._inherit_handlers.clear()
 
     cdef _reload_lazy_handlers(self):
+        missing = object()
         for k in list(self._lazy_handlers):
-            v = self._lazy_handlers.pop(k)
+            v = self._lazy_handlers.pop(k, missing)
+            if v is missing:
+                # A nested or concurrent reload may have already consumed it.
+                continue
             mod_name, obj_name = k.rsplit('.', 1)
             try:
                 with warnings.catch_warnings():

--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -66,7 +66,8 @@ cdef class TypeDispatcher:
             self._inherit_handlers.clear()
 
     cdef _reload_lazy_handlers(self):
-        for k, v in self._lazy_handlers.items():
+        for k in list(self._lazy_handlers):
+            v = self._lazy_handlers.pop(k)
             mod_name, obj_name = k.rsplit('.', 1)
             try:
                 with warnings.catch_warnings():
@@ -85,7 +86,6 @@ cdef class TypeDispatcher:
                 logger.debug("Failed to load lazy handler %s", k, exc_info=True)
                 continue
             self.register(obj_type, v)
-        self._lazy_handlers = dict()
 
     cpdef get_handler(self, object type_):
         try:

--- a/python/xoscar/_utils.pyx
+++ b/python/xoscar/_utils.pyx
@@ -17,6 +17,7 @@
 import collections
 import importlib
 import itertools
+import logging
 import time
 import warnings
 from functools import partial
@@ -35,6 +36,7 @@ cdef mt19937_64 _rnd_gen
 cdef bint _rnd_is_seed_set = False
 NamedType = collections.namedtuple("NamedType", ["name", "type_"])
 _type_dispatchers = WeakSet()
+logger = logging.getLogger(__name__)
 
 cdef class TypeDispatcher:
     def __init__(self):
@@ -66,13 +68,23 @@ cdef class TypeDispatcher:
     cdef _reload_lazy_handlers(self):
         for k, v in self._lazy_handlers.items():
             mod_name, obj_name = k.rsplit('.', 1)
-            with warnings.catch_warnings():
-                # the lazy imported cudf will warn no device found,
-                # when we set visible device to -1 for CPU processes,
-                # ignore the warning to not distract users
-                warnings.simplefilter("ignore")
-                mod = importlib.import_module(mod_name, __name__)
-            self.register(getattr(mod, obj_name), v)
+            try:
+                with warnings.catch_warnings():
+                    # the lazy imported cudf will warn no device found,
+                    # when we set visible device to -1 for CPU processes,
+                    # ignore the warning to not distract users
+                    warnings.simplefilter("ignore")
+                    mod = importlib.import_module(mod_name, __name__)
+                obj_type = getattr(mod, obj_name)
+            except Exception:
+                # Lazy handlers are used for optional dependencies.  A module can
+                # be discoverable in a child process yet fail to import there
+                # because a transitive dependency or shared library is absent or
+                # incompatible.  Skip only that handler so unrelated actor-pool
+                # startup and serialization remain available.
+                logger.debug("Failed to load lazy handler %s", k, exc_info=True)
+                continue
+            self.register(obj_type, v)
         self._lazy_handlers = dict()
 
     cpdef get_handler(self, object type_):

--- a/python/xoscar/tests/test_utils.py
+++ b/python/xoscar/tests/test_utils.py
@@ -172,6 +172,26 @@ def test_type_dispatcher_skips_unimportable_lazy_handler(monkeypatch):
     assert dispatcher(pd.DataFrame()) == "DataFrame"
 
 
+def test_type_dispatcher_keeps_lazy_handler_registered_during_import(monkeypatch):
+    dispatcher = utils.TypeDispatcher()
+    real_import_module = importlib.import_module
+
+    class ImportedType:
+        pass
+
+    def import_module(name, package=None):
+        if name == "registering_optional":
+            dispatcher.register("builtins.str", lambda x: "String")
+            return type("Module", (), {"Type": ImportedType})
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+    dispatcher.register("registering_optional.Type", lambda x: "Imported")
+
+    assert dispatcher(ImportedType()) == "Imported"
+    assert dispatcher("value") == "String"
+
+
 def test_timer():
     with utils.Timer() as timer:
         time.sleep(0.1)

--- a/python/xoscar/tests/test_utils.py
+++ b/python/xoscar/tests/test_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 import shutil
 import sys
@@ -153,6 +154,22 @@ def test_type_dispatcher():
     dispatcher.unregister(object)
     with pytest.raises(KeyError):
         dispatcher(type3())
+
+
+def test_type_dispatcher_skips_unimportable_lazy_handler(monkeypatch):
+    dispatcher = utils.TypeDispatcher()
+    real_import_module = importlib.import_module
+
+    def import_module(name, package=None):
+        if name == "broken_optional":
+            raise AttributeError("incompatible optional dependency")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+    dispatcher.register("broken_optional.Type", lambda x: "Broken")
+    dispatcher.register("pandas.DataFrame", lambda x: "DataFrame")
+
+    assert dispatcher(pd.DataFrame()) == "DataFrame"
 
 
 def test_timer():

--- a/python/xoscar/tests/test_utils.py
+++ b/python/xoscar/tests/test_utils.py
@@ -192,6 +192,29 @@ def test_type_dispatcher_keeps_lazy_handler_registered_during_import(monkeypatch
     assert dispatcher("value") == "String"
 
 
+def test_type_dispatcher_handles_reentrant_lazy_reload(monkeypatch):
+    dispatcher = utils.TypeDispatcher()
+    real_import_module = importlib.import_module
+    reentrant_results = []
+
+    class ImportedType:
+        pass
+
+    def import_module(name, package=None):
+        if name == "reentrant_optional":
+            reentrant_results.append(dispatcher("value"))
+            return type("Module", (), {"Type": ImportedType})
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+    dispatcher.register("reentrant_optional.Type", lambda x: "Imported")
+    dispatcher.register("builtins.str", lambda x: "String")
+
+    assert dispatcher(ImportedType()) == "Imported"
+    assert reentrant_results == ["String"]
+    assert dispatcher("value") == "String"
+
+
 def test_timer():
     with utils.Timer() as timer:
         time.sleep(0.1)


### PR DESCRIPTION
## Summary

- Skip an individual lazy serialization handler when its optional module is discoverable but fails to import.
- Continue loading usable handlers so actor-pool startup is not blocked.
- Add regression coverage for a failed optional import followed by a valid handler.

## Root cause

Lazy handlers represent optional dependencies, but reload_all_lazy_handlers aborted on any import-time exception. A child process can therefore fail during startup when it inherits an optional parent package such as cuDF while using incompatible child-environment versions of pandas or NumPy.

## Validation

- python -m pytest -q xoscar/tests/test_utils.py
- pre-commit run --files python/xoscar/_utils.pyx python/xoscar/tests/test_utils.py