### PR TITLE
BLD: use manylinux_2_28 image for Linux wheels

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,3 +54,16 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 skip = "pp* *musllinux* *i686 cp38-win32 cp39-win32 cp310-win32 cp311-win32 cp312-win32 cp313-win32"
 manylinux-x86_64-image = "manylinux2014"
+
+# CPython 3.12+ needs a newer image on x86_64. manylinux2014 ships GCC 10.2.1,
+# which is too old to build numpy from source (numpy requires GCC >= 10.3), and
+# recent numpy/pandas releases only publish manylinux_2_28 wheels -- so pip
+# falls back to a source build inside the container and fails. That happens both
+# when resolving build requirements and when installing runtime dependencies
+# during the test phase, which pins in build-system.requires do not constrain.
+# manylinux_2_28 ships GCC 14 and has matching wheels for both phases.
+# CPython 3.9-3.11 stay on manylinux2014 to keep their glibc 2.17 baseline;
+# numpy and pandas still publish manylinux2014 wheels for those versions.
+[[tool.cibuildwheel.overrides]]
+select = "cp312-* cp313-*"
+manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
Scope the new image to CPython 3.12/3.13 on x86_64 via a cibuildwheel override, instead of switching it globally. Rebased on top of #198; the build requirement pins from that PR are kept.

## Why

`manylinux2014` ships **GCC 10.2.1**, and recent numpy and pandas releases only publish `manylinux_2_24/2_28` wheels. Inside the manylinux2014 container (glibc 2.17) those tags are incompatible, so pip falls back to a source build and numpy's meson configure step rejects the compiler:

```
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
```

This happens in **two independent phases**, which is why pinning fixed the first failure but not the release:

**1. Resolving `build-system.requires`** — `pandas>=2.1.1` resolved to pandas 3.0.5, which transitively pulled numpy 2.5.1. #198 pinned this, and it worked: the build phase now completes and the wheel is produced.

**2. Installing runtime dependencies in the cibuildwheel test phase** — after the wheel is built and repaired, cibuildwheel installs it into a test venv, which resolves `numpy>=1.14.0` from `setup.cfg`. Pins in `build-system.requires` don't apply there, so numpy 2.5.1 is selected again:

```
##[group]Building wheel...        <- succeeds, pins in effect
##[group]Testing wheel...
    + pip install .../xoscar-0.9.7-cp312-cp312-manylinux2014_x86_64.whl
Collecting numpy>=1.14.0 (from xoscar==0.9.7)
  Downloading numpy-2.5.1.tar.gz (20.8 MB)
      ../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
```

Run [30334853385](https://github.com/xorbitsai/xoscar/actions/runs/30334853385) (v0.9.7 retag, with #198 merged) still failed on cp312/cp313 Linux x86_64 for this reason, so `upload_pypi` was skipped again.

## How

```toml
manylinux-x86_64-image = "manylinux2014"

[[tool.cibuildwheel.overrides]]
select = "cp312-* cp313-*"
manylinux-x86_64-image = "manylinux_2_28"
```

`manylinux_2_28` ships GCC 14 and has matching numpy/pandas wheels, so no source build happens in either phase. Scoping it to the affected versions keeps the change off the builds that already pass.

## On preserving the 3.9–3.11 baseline

Addressing @qinxuye's review — the concern is right and the previous revision of this PR was wrong about it. I had claimed the older glibc platforms were already unsupported, but that only holds for 3.12+. For 3.9–3.11 there are plenty of usable versions on glibc 2.17, since the runtime requirements are lower bounds:

| | newest versions with manylinux2014 x86_64 wheels |
|---|---|
| numpy cp39 | 2.0.0, 2.0.1, 2.0.2 |
| numpy cp310 / cp311 | 2.2.4, 2.2.5, 2.2.6 |
| pandas cp39 / cp310 / cp311 | 2.3.0, 2.3.1, 2.3.2 |

So switching globally would have made working glibc 2.17 wheels unavailable for three Python versions that never failed. Now scoped to cp312/cp313 only.

Also confirmed that the image affects the artifact baseline, not just the compiler — the aarch64 wheel in that run repairs to `manylinux_2_26/2_28`:

```
xoscar-0.9.7-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
```

`aarch64` is now left untouched (the previous revision pinned it needlessly). It never set an image and picks up cibuildwheel's `manylinux_2_28` default, which is why it passed throughout both failures.

## Verification

Resolved the config through cibuildwheel 3.1.0's own options parser to confirm the override applies where intended and nowhere else:

```
cp39-manylinux_x86_64          -> quay.io/pypa/manylinux2014_x86_64:2025.07.23-1
cp311-manylinux_x86_64         -> quay.io/pypa/manylinux2014_x86_64:2025.07.23-1
cp312-manylinux_x86_64         -> quay.io/pypa/manylinux_2_28_x86_64:2025.07.23-1
cp313-manylinux_x86_64         -> quay.io/pypa/manylinux_2_28_x86_64:2025.07.23-1

cp39-manylinux_aarch64         -> quay.io/pypa/manylinux_2_28_aarch64:2025.07.23-1
cp313-manylinux_aarch64        -> quay.io/pypa/manylinux_2_28_aarch64:2025.07.23-1
```

Python CI does not build manylinux wheels, so a green run here does not exercise this setting. A full `build-wheel.yaml` run on this head is still needed before merge — agreed, and especially warranted given that #198 passed its own CI and still failed at release time.
