### PR TITLE
ENH: Add TCP_USER_TIMEOUT to prevent indefinite RPC hangs on dead connections

### DIFF
--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -314,27 +314,44 @@ class SocketClient(Client):
             reader, writer = await asyncio.wait_for(fut, timeout=connect_timeout)
         except asyncio.TimeoutError:
             raise ConnectionError("connect timeout")
-        # Enable TCP keepalive to detect silently dropped connections
+        # Enable TCP keepalive to detect silently dropped connections.
+        # Use relatively aggressive defaults (30s idle, 5s interval, 3 probes
+        # ≈ 45s total) so that dead hosts are detected quickly even on macOS
+        # and Windows which lack TCP_USER_TIMEOUT.
         sock = writer.get_extra_info("socket")
         if sock is not None:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             if hasattr(socket, "TCP_KEEPIDLE"):
                 # Linux
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 30)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 5)
                 sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
             elif sys.platform == "darwin":
-                # macOS uses TCP_KEEPALIVE instead of TCP_KEEPIDLE
                 TCP_KEEPALIVE_DARWIN = 0x10
-                sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE_DARWIN, 60)
+                sock.setsockopt(socket.IPPROTO_TCP, TCP_KEEPALIVE_DARWIN, 30)
             elif _is_windows:
-                # Windows: use SIO_KEEPALIVE_VALS via ioctl
-                # struct: (onoff, keepalivetime_ms, keepaliveinterval_ms)
                 import struct
 
                 sock.ioctl(
                     socket.SIO_KEEPALIVE_VALS,  # type: ignore[attr-defined]
-                    struct.pack("III", 1, 60 * 1000, 10 * 1000),
+                    struct.pack("III", 1, 30 * 1000, 5 * 1000),
+                )
+
+            # TCP_USER_TIMEOUT (Linux 2.6.37+): force-close the connection
+            # when the remote TCP stack stops acknowledging data for the
+            # specified duration (ms). Unlike SO_SNDTIMEO/SO_RCVTIMEO,
+            # this works with non-blocking sockets because it operates at
+            # the TCP protocol level rather than the socket I/O level.
+            # When triggered, the kernel sends RST → asyncio StreamReader
+            # receives EOF → _listen() raises ServerClosed → all pending
+            # message futures are resolved with an error, preventing
+            # indefinite RPC hangs.
+            if hasattr(socket, "TCP_USER_TIMEOUT"):
+                tcp_user_timeout = int(
+                    os.environ.get("XOSCAR_TCP_USER_TIMEOUT", "30000")
+                )
+                sock.setsockopt(
+                    socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, tcp_user_timeout
                 )
         channel = SocketChannel(
             reader,

--- a/python/xoscar/backends/communication/socket.py
+++ b/python/xoscar/backends/communication/socket.py
@@ -347,12 +347,31 @@ class SocketClient(Client):
             # message futures are resolved with an error, preventing
             # indefinite RPC hangs.
             if hasattr(socket, "TCP_USER_TIMEOUT"):
-                tcp_user_timeout = int(
-                    os.environ.get("XOSCAR_TCP_USER_TIMEOUT", "30000")
-                )
-                sock.setsockopt(
-                    socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, tcp_user_timeout
-                )
+                try:
+                    tcp_user_timeout = int(
+                        os.environ.get("XOSCAR_TCP_USER_TIMEOUT", "30000")
+                    )
+                    if tcp_user_timeout < 0:
+                        raise ValueError("Timeout must be non-negative")
+                except ValueError:
+                    logger.warning(
+                        "Invalid XOSCAR_TCP_USER_TIMEOUT environment variable. "
+                        "Falling back to 30000 ms."
+                    )
+                    tcp_user_timeout = 30_000
+                try:
+                    sock.setsockopt(
+                        socket.IPPROTO_TCP,
+                        socket.TCP_USER_TIMEOUT,
+                        tcp_user_timeout,
+                    )
+                except OSError as e:
+                    logger.warning(
+                        "Failed to set TCP_USER_TIMEOUT: %s. "
+                        "The kernel may not support this option "
+                        "(e.g., WSL, gVisor, or restricted containers).",
+                        e,
+                    )
         channel = SocketChannel(
             reader,
             writer,


### PR DESCRIPTION
## Problem

Xoscar RPC calls can hang indefinitely when the remote worker becomes unresponsive, even with application-level timeouts (`xo.wait_for` / `asyncio.wait_for`). The codebase itself acknowledges this issue at `xoscar/api.py:185-190`.

While PR #189 added TCP keepalive to detect dead hosts, keepalive alone cannot cover all failure modes — particularly when the remote TCP stack stops ACKing data (e.g., `SIGSTOP`, kernel panic, network partition after connection establishment).

## Solution

Add `TCP_USER_TIMEOUT` (Linux 2.6.37+) to force-close connections when the remote TCP stack stops acknowledging data. Unlike `SO_SNDTIMEO`/`SO_RCVTIMEO`, this works with non-blocking sockets because it operates at the TCP protocol layer, not the socket I/O layer.

### How it works

```
TCP_USER_TIMEOUT triggered → kernel sends RST → asyncio StreamReader
receives EOF → _listen() raises ServerClosed → all pending message
futures are resolved with an error
```

### Changes (1 file: `socket.py`)

1. **Add `TCP_USER_TIMEOUT`** (default 30s, configurable via `XOSCAR_TCP_USER_TIMEOUT` env var)
2. **Optimize keepalive parameters**: idle 60s→30s, interval 10s→5s, reducing total detection time from ~90s to ~45s — especially important for macOS and Windows which lack `TCP_USER_TIMEOUT`

### Mechanism comparison

| Mechanism | Detects | Non-blocking socket | Platform |
|-----------|---------|---------------------|----------|
| **TCP_USER_TIMEOUT** | Remote TCP stack not ACKing | ✅ Works | Linux |
| **TCP keepalive** | Remote host dead | ✅ Works | All |
| `SO_SNDTIMEO`/`SO_RCVTIMEO` | — | ❌ Ignored by kernel | All |

### Trigger scenarios

TCP_USER_TIMEOUT triggers when:
- Remote worker process is frozen by `SIGSTOP` (TCP stack doesn't ACK)
- Network partition prevents packet delivery
- Remote host crashes (hard shutdown, no FIN/RST)
- Remote kernel panic

Not triggered when TCP is healthy but application layer is hung (covered by `xo.wait_for`).

### Risk assessment

- **Normal connections unaffected**: only triggers when remote stops ACKing
- **30s default is conservative**: far longer than normal RPC latency (milliseconds)
- **Backward compatible**: pure incremental change, `hasattr` guard for non-Linux platforms
- **Configurable**: `XOSCAR_TCP_USER_TIMEOUT` env var for custom timeout

### Verification

1. ✅ Normal: supervisor + worker RPC calls work correctly
2. ✅ Frozen remote: `kill -STOP <worker_pid>` → supervisor receives `ServerClosed` within 30s
3. ✅ Network interruption: `iptables -A INPUT -p tcp --dport <port> -j DROP` → timeout within 30s
4. ✅ Cross-platform: Linux/macOS/Windows connection establishment verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)